### PR TITLE
feat: 회원가입 이메일 및 닉네임 중복체크 GET API 구현

### DIFF
--- a/src/main/java/com/konkuk/Eodikase/domain/member/controller/MemberController.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.konkuk.Eodikase.domain.member.controller;
 
 import com.konkuk.Eodikase.domain.member.dto.request.MemberSignUpRequest;
 import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateEmailResponse;
+import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateNicknameResponse;
 import com.konkuk.Eodikase.domain.member.dto.response.MemberSignUpResponse;
 import com.konkuk.Eodikase.domain.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -31,6 +32,13 @@ public class MemberController {
     @GetMapping("/check-duplicate/email")
     public ResponseEntity<IsDuplicateEmailResponse> checkDuplicateEmail(@RequestParam String value) {
         IsDuplicateEmailResponse response = memberService.isDuplicateEmail(value);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "회원가입 닉네임 중복체크")
+    @GetMapping("/check-duplicate/nickname")
+    public ResponseEntity<IsDuplicateNicknameResponse> checkDuplicateNickname(@RequestParam String value) {
+        IsDuplicateNicknameResponse response = memberService.isDuplicateNickname(value);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/controller/MemberController.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/controller/MemberController.java
@@ -1,16 +1,14 @@
 package com.konkuk.Eodikase.domain.member.controller;
 
 import com.konkuk.Eodikase.domain.member.dto.request.MemberSignUpRequest;
+import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateEmailResponse;
 import com.konkuk.Eodikase.domain.member.dto.response.MemberSignUpResponse;
 import com.konkuk.Eodikase.domain.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -26,6 +24,13 @@ public class MemberController {
     @PostMapping
     public ResponseEntity<MemberSignUpResponse> signUp(@RequestBody @Valid MemberSignUpRequest request) {
         MemberSignUpResponse response = memberService.signUp(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "회원가입 이메일 중복체크")
+    @GetMapping("/check-duplicate/email")
+    public ResponseEntity<IsDuplicateEmailResponse> checkDuplicateEmail(@RequestParam String value) {
+        IsDuplicateEmailResponse response = memberService.isDuplicateEmail(value);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/dto/request/MemberSignUpRequest.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/dto/request/MemberSignUpRequest.java
@@ -13,13 +13,13 @@ import javax.validation.constraints.NotBlank;
 @Getter
 public class MemberSignUpRequest {
 
-    @Email(message = "1006:이메일 형식이 올바르지 않습니다.")
-    @NotBlank(message = "1012:공백일 수 없습니다.")
+    @Email(message = "1004:이메일 형식이 올바르지 않습니다.")
+    @NotBlank(message = "1005:공백일 수 없습니다.")
     private String email;
 
-    @NotBlank(message = "1012:공백일 수 없습니다.")
+    @NotBlank(message = "1005:공백일 수 없습니다.")
     private String password;
 
-    @NotBlank(message = "1012:공백일 수 없습니다.")
+    @NotBlank(message = "1005:공백일 수 없습니다.")
     private String nickname;
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/dto/response/IsDuplicateEmailResponse.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/dto/response/IsDuplicateEmailResponse.java
@@ -11,8 +11,4 @@ import lombok.NoArgsConstructor;
 public class IsDuplicateEmailResponse {
 
     private boolean result;
-
-    public boolean isDuplicate() {
-        return result;
-    }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/dto/response/IsDuplicateEmailResponse.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/dto/response/IsDuplicateEmailResponse.java
@@ -1,0 +1,18 @@
+package com.konkuk.Eodikase.domain.member.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class IsDuplicateEmailResponse {
+
+    private boolean result;
+
+    public boolean isDuplicate() {
+        return result;
+    }
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/member/dto/response/IsDuplicateNicknameResponse.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/dto/response/IsDuplicateNicknameResponse.java
@@ -11,8 +11,4 @@ import lombok.NoArgsConstructor;
 public class IsDuplicateNicknameResponse {
 
     private boolean result;
-
-    public boolean isDuplicate() {
-        return result;
-    }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/dto/response/IsDuplicateNicknameResponse.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/dto/response/IsDuplicateNicknameResponse.java
@@ -1,0 +1,18 @@
+package com.konkuk.Eodikase.domain.member.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class IsDuplicateNicknameResponse {
+
+    private boolean result;
+
+    public boolean isDuplicate() {
+        return result;
+    }
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/member/entity/Member.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/entity/Member.java
@@ -1,10 +1,10 @@
 package com.konkuk.Eodikase.domain.member.entity;
+
 import com.konkuk.Eodikase.domain.audit.BaseEntity;
 import com.konkuk.Eodikase.domain.bookmark.entity.Bookmark;
 import com.konkuk.Eodikase.domain.comment.entity.Comment;
 import com.konkuk.Eodikase.domain.course.entity.Course;
 import com.konkuk.Eodikase.domain.review.entity.Review;
-import com.konkuk.Eodikase.exception.badrequest.InvalidNicknameException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +12,6 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 
 
 @Entity
@@ -20,8 +19,6 @@ import java.util.regex.Pattern;
 @Table(name = "member")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
-
-    private static final Pattern NICKNAME_REGEX = Pattern.compile("^[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣]{2,6}$");
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -58,18 +55,11 @@ public class Member extends BaseEntity {
     private MemberRole role;
 
     public Member(String email, String password, String nickname, MemberPlatform platform) {
-        validateNickname(nickname);
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.status = MemberStatus.MEMBER_ACTIVE;
         this.role = MemberRole.USER;
         this.platform = platform;
-    }
-
-    private void validateNickname(String nickname) {
-        if (!NICKNAME_REGEX.matcher(nickname).matches()) {
-            throw new InvalidNicknameException();
-        }
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
@@ -20,7 +20,8 @@ public class MemberService {
 
     private static final Pattern PASSWORD_REGEX = Pattern
             .compile("^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}");
-    private static final Pattern EMAIL_REGEX = Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+    private static final Pattern EMAIL_REGEX = Pattern
+            .compile("^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$");
     private static final Pattern NICKNAME_REGEX = Pattern.compile("^[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣]{2,8}$");
 
     private final MemberRepository memberRepository;

--- a/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
@@ -20,8 +20,6 @@ public class MemberService {
 
     private static final Pattern PASSWORD_REGEX = Pattern
             .compile("^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}");
-    private static final Pattern EMAIL_REGEX = Pattern
-            .compile("^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$");
     private static final Pattern NICKNAME_REGEX = Pattern.compile("^[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣]{2,8}$");
 
     private final MemberRepository memberRepository;
@@ -63,7 +61,7 @@ public class MemberService {
     }
 
     private void validateEmail(String email) {
-        if (email.isBlank() || !EMAIL_REGEX.matcher(email).matches()) {
+        if (email.isBlank()) {
             throw new InvalidEmailException();
         }
     }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
@@ -1,12 +1,14 @@
 package com.konkuk.Eodikase.domain.member.service;
 
+import com.konkuk.Eodikase.domain.member.dto.request.MemberSignUpRequest;
+import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateEmailResponse;
+import com.konkuk.Eodikase.domain.member.dto.response.MemberSignUpResponse;
 import com.konkuk.Eodikase.domain.member.entity.Member;
 import com.konkuk.Eodikase.domain.member.entity.MemberPlatform;
 import com.konkuk.Eodikase.domain.member.repository.MemberRepository;
-import com.konkuk.Eodikase.domain.member.dto.request.MemberSignUpRequest;
-import com.konkuk.Eodikase.domain.member.dto.response.MemberSignUpResponse;
 import com.konkuk.Eodikase.exception.badrequest.DuplicateMemberException;
 import com.konkuk.Eodikase.exception.badrequest.DuplicateNicknameException;
+import com.konkuk.Eodikase.exception.badrequest.InvalidEmailException;
 import com.konkuk.Eodikase.exception.badrequest.InvalidPasswordException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -20,6 +22,9 @@ public class MemberService {
 
     private static final Pattern PASSWORD_REGEX = Pattern
             .compile("^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}");
+    private static final Pattern EMAIL_REGEX = Pattern
+            .compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
@@ -48,6 +53,19 @@ public class MemberService {
     private void validatePassword(String password) {
         if (!PASSWORD_REGEX.matcher(password).matches()) {
             throw new InvalidPasswordException();
+        }
+    }
+
+    public IsDuplicateEmailResponse isDuplicateEmail(String email) {
+        validateEmail(email);
+
+        boolean existsEmail = memberRepository.existsByEmailAndPlatform(email, MemberPlatform.HOME);
+        return new IsDuplicateEmailResponse(existsEmail);
+    }
+
+    private void validateEmail(String email) {
+        if (email.isBlank() || !EMAIL_REGEX.matcher(email).matches()) {
+            throw new InvalidEmailException();
         }
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
@@ -2,14 +2,12 @@ package com.konkuk.Eodikase.domain.member.service;
 
 import com.konkuk.Eodikase.domain.member.dto.request.MemberSignUpRequest;
 import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateEmailResponse;
+import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateNicknameResponse;
 import com.konkuk.Eodikase.domain.member.dto.response.MemberSignUpResponse;
 import com.konkuk.Eodikase.domain.member.entity.Member;
 import com.konkuk.Eodikase.domain.member.entity.MemberPlatform;
 import com.konkuk.Eodikase.domain.member.repository.MemberRepository;
-import com.konkuk.Eodikase.exception.badrequest.DuplicateMemberException;
-import com.konkuk.Eodikase.exception.badrequest.DuplicateNicknameException;
-import com.konkuk.Eodikase.exception.badrequest.InvalidEmailException;
-import com.konkuk.Eodikase.exception.badrequest.InvalidPasswordException;
+import com.konkuk.Eodikase.exception.badrequest.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -22,9 +20,8 @@ public class MemberService {
 
     private static final Pattern PASSWORD_REGEX = Pattern
             .compile("^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}");
-    private static final Pattern EMAIL_REGEX = Pattern
-            .compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
-
+    private static final Pattern EMAIL_REGEX = Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+    private static final Pattern NICKNAME_REGEX = Pattern.compile("^[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣]{2,8}$");
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
@@ -32,6 +29,7 @@ public class MemberService {
     public MemberSignUpResponse signUp(MemberSignUpRequest request) {
         validateDuplicateMember(request);
         validatePassword(request.getPassword());
+        validateNickname(request.getNickname());
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
         Member member = new Member(request.getEmail(), encodedPassword, request.getNickname(), MemberPlatform.HOME);
@@ -66,6 +64,19 @@ public class MemberService {
     private void validateEmail(String email) {
         if (email.isBlank() || !EMAIL_REGEX.matcher(email).matches()) {
             throw new InvalidEmailException();
+        }
+    }
+
+    public IsDuplicateNicknameResponse isDuplicateNickname(String nickname) {
+        validateNickname(nickname);
+
+        boolean existsNickname = memberRepository.existsByNickname(nickname);
+        return new IsDuplicateNicknameResponse(existsNickname);
+    }
+
+    private void validateNickname(String nickname) {
+        if (nickname.isBlank() || !NICKNAME_REGEX.matcher(nickname).matches()) {
+            throw new InvalidNicknameException();
         }
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/exception/badrequest/InvalidEmailException.java
+++ b/src/main/java/com/konkuk/Eodikase/exception/badrequest/InvalidEmailException.java
@@ -3,6 +3,6 @@ package com.konkuk.Eodikase.exception.badrequest;
 public class InvalidEmailException extends BadRequestException {
 
     public InvalidEmailException() {
-        super("이메일 형식이 올바르지 않습니다.", 1005);
+        super("이메일 형식이 올바르지 않습니다.", 1004);
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/exception/badrequest/InvalidEmailException.java
+++ b/src/main/java/com/konkuk/Eodikase/exception/badrequest/InvalidEmailException.java
@@ -1,0 +1,8 @@
+package com.konkuk.Eodikase.exception.badrequest;
+
+public class InvalidEmailException extends BadRequestException {
+
+    public InvalidEmailException() {
+        super("이메일 형식이 올바르지 않습니다.", 1005);
+    }
+}

--- a/src/test/java/com/konkuk/Eodikase/service/MemberServiceTest.java
+++ b/src/test/java/com/konkuk/Eodikase/service/MemberServiceTest.java
@@ -7,10 +7,7 @@ import com.konkuk.Eodikase.domain.member.entity.Member;
 import com.konkuk.Eodikase.domain.member.entity.MemberPlatform;
 import com.konkuk.Eodikase.domain.member.repository.MemberRepository;
 import com.konkuk.Eodikase.domain.member.service.MemberService;
-import com.konkuk.Eodikase.exception.badrequest.DuplicateMemberException;
-import com.konkuk.Eodikase.exception.badrequest.DuplicateNicknameException;
-import com.konkuk.Eodikase.exception.badrequest.InvalidNicknameException;
-import com.konkuk.Eodikase.exception.badrequest.InvalidPasswordException;
+import com.konkuk.Eodikase.exception.badrequest.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -115,7 +112,7 @@ public class MemberServiceTest {
 
         IsDuplicateEmailResponse response = memberService.isDuplicateEmail(email);
 
-        assertThat(response.isDuplicate()).isTrue();
+        assertThat(response.isResult()).isTrue();
     }
 
     @Test
@@ -125,7 +122,7 @@ public class MemberServiceTest {
 
         IsDuplicateEmailResponse response = memberService.isDuplicateEmail(email);
 
-        assertThat(response.isDuplicate()).isFalse();
+        assertThat(response.isResult()).isFalse();
     }
 
     @Test

--- a/src/test/java/com/konkuk/Eodikase/service/MemberServiceTest.java
+++ b/src/test/java/com/konkuk/Eodikase/service/MemberServiceTest.java
@@ -158,7 +158,7 @@ public class MemberServiceTest {
     }
 
     @ParameterizedTest
-    @DisplayName("비밀번호가 영어, 한글을 제외한 문자가 들어오면 예외를 반환한다")
+    @DisplayName("닉네임에 영어, 한글을 제외한 문자가 들어오면 예외를 반환한다")
     @ValueSource(strings = {"123456", "abc1234", "감자!!!!"})
     void nicknameConfigureValidation(String nickname) {
         assertThatThrownBy(() -> memberService.signUp(new MemberSignUpRequest("dlawotn3@naver.com",

--- a/src/test/java/com/konkuk/Eodikase/service/MemberServiceTest.java
+++ b/src/test/java/com/konkuk/Eodikase/service/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package com.konkuk.Eodikase.service;
 
 import com.konkuk.Eodikase.domain.member.dto.request.MemberSignUpRequest;
+import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateEmailResponse;
 import com.konkuk.Eodikase.domain.member.entity.Member;
 import com.konkuk.Eodikase.domain.member.entity.MemberPlatform;
 import com.konkuk.Eodikase.domain.member.repository.MemberRepository;
@@ -101,5 +102,27 @@ public class MemberServiceTest {
         assertThatThrownBy(() -> memberService.signUp(new MemberSignUpRequest("dlawotn3@naver.com",
                 password, "감자")))
                 .isInstanceOf(InvalidPasswordException.class);
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 이메일인 경우 True를 반환한다")
+    void isDuplicateEmailReturnTrue(){
+        String email = "dlawotn3@naver.com";
+        MemberSignUpRequest request = new MemberSignUpRequest(email, "edks123!", "감자");
+        memberService.signUp(request);
+
+        IsDuplicateEmailResponse response = memberService.isDuplicateEmail(email);
+
+        assertThat(response.isDuplicate()).isTrue();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이메일인 경우 False를 반환한다")
+    void isDuplicateEmailReturnFalse(){
+        String email = "dlawotn3@naver.com";
+
+        IsDuplicateEmailResponse response = memberService.isDuplicateEmail(email);
+
+        assertThat(response.isDuplicate()).isFalse();
     }
 }

--- a/src/test/java/com/konkuk/Eodikase/service/MemberServiceTest.java
+++ b/src/test/java/com/konkuk/Eodikase/service/MemberServiceTest.java
@@ -2,12 +2,14 @@ package com.konkuk.Eodikase.service;
 
 import com.konkuk.Eodikase.domain.member.dto.request.MemberSignUpRequest;
 import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateEmailResponse;
+import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateNicknameResponse;
 import com.konkuk.Eodikase.domain.member.entity.Member;
 import com.konkuk.Eodikase.domain.member.entity.MemberPlatform;
 import com.konkuk.Eodikase.domain.member.repository.MemberRepository;
 import com.konkuk.Eodikase.domain.member.service.MemberService;
 import com.konkuk.Eodikase.exception.badrequest.DuplicateMemberException;
 import com.konkuk.Eodikase.exception.badrequest.DuplicateNicknameException;
+import com.konkuk.Eodikase.exception.badrequest.InvalidNicknameException;
 import com.konkuk.Eodikase.exception.badrequest.InvalidPasswordException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -108,7 +110,7 @@ public class MemberServiceTest {
     @DisplayName("이미 존재하는 이메일인 경우 True를 반환한다")
     void isDuplicateEmailReturnTrue(){
         String email = "dlawotn3@naver.com";
-        MemberSignUpRequest request = new MemberSignUpRequest(email, "edks123!", "감자");
+        MemberSignUpRequest request = new MemberSignUpRequest(email, "edks1234!", "감자");
         memberService.signUp(request);
 
         IsDuplicateEmailResponse response = memberService.isDuplicateEmail(email);
@@ -124,5 +126,46 @@ public class MemberServiceTest {
         IsDuplicateEmailResponse response = memberService.isDuplicateEmail(email);
 
         assertThat(response.isDuplicate()).isFalse();
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 닉네임인 경우 True를 반환한다")
+    void isDuplicateNicknameReturnTrue() {
+        String nickname = "감자";
+        MemberSignUpRequest request = new MemberSignUpRequest("dlawotn3@naver.com", "edks1234!",
+                nickname);
+        memberService.signUp(request);
+
+        IsDuplicateNicknameResponse response = memberService.isDuplicateNickname(nickname);
+
+        assertThat(response.isResult()).isTrue();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 닉네임인 경우 False를 반환한다")
+    void isDuplicateNicknameReturnFalse() {
+        String nickname = "감자";
+
+        IsDuplicateNicknameResponse response = memberService.isDuplicateNickname(nickname);
+
+        assertThat(response.isResult()).isFalse();
+    }
+
+    @ParameterizedTest
+    @DisplayName("닉네임이 2~8자가 아니면 예외를 반환한다")
+    @ValueSource(strings = {"감", "감자포테이토예에에"})
+    void nicknameLengthValidation(String nickname) {
+        assertThatThrownBy(() -> memberService.signUp(new MemberSignUpRequest("dlawotn3@naver.com",
+                "edks1234!", nickname)))
+                .isInstanceOf(InvalidNicknameException.class);
+    }
+
+    @ParameterizedTest
+    @DisplayName("비밀번호가 영어, 한글을 제외한 문자가 들어오면 예외를 반환한다")
+    @ValueSource(strings = {"123456", "abc1234", "감자!!!!"})
+    void nicknameConfigureValidation(String nickname) {
+        assertThatThrownBy(() -> memberService.signUp(new MemberSignUpRequest("dlawotn3@naver.com",
+                "edks1234!", nickname)))
+                .isInstanceOf(InvalidNicknameException.class);
     }
 }


### PR DESCRIPTION
### 개요
일반적으로 회원가입 페이지에서 이메일 및 닉네임 중복체크 검증이 회원가입 완료하기 전에 한번 더 수행되기 때문에 해당 API를 구현했습니다.

### 작업사항
+ 이메일 중복체크 GET API 구현
+ 닉네임 중복체크 GET API 구현
+ 이메일 및 닉네임 중복체크 테스트 코드 작성

### 주의사항
+ postman이나 swagger를 통해 해당 기능이 작동되는지, 관련 커스텀 예외가 잘 반환되는지 확인해주세요
+ 기획 로직과 다르게 구현된 부분이 있는지 확인해주세요
+ 오타가 있는지 확인해주세요