### PR TITLE
feat: 회원정보 수정 PUT API 구현

### DIFF
--- a/src/main/java/com/konkuk/Eodikase/config/AuthConfig.java
+++ b/src/main/java/com/konkuk/Eodikase/config/AuthConfig.java
@@ -1,23 +1,33 @@
 package com.konkuk.Eodikase.config;
 
+import com.konkuk.Eodikase.security.auth.AuthenticationPrincipalArgumentResolver;
 import com.konkuk.Eodikase.security.auth.LoginInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-@Configuration
-public class AuthConfig implements WebMvcConfigurer {
-    private final LoginInterceptor loginInterceptor;
+import java.util.List;
 
-    public AuthConfig(final LoginInterceptor loginInterceptor) {
-        this.loginInterceptor = loginInterceptor;
-    }
+@Configuration
+@RequiredArgsConstructor
+public class AuthConfig implements WebMvcConfigurer {
+
+    private final LoginInterceptor loginInterceptor;
+    private final AuthenticationPrincipalArgumentResolver authenticationPrincipalArgumentResolver;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(loginInterceptor)
-                .addPathPatterns("/**")
+                .addPathPatterns("/v1/members/**")
                 .excludePathPatterns("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs", "/error")
-                .excludePathPatterns("/v1/members", "/v1/login");
+                .excludePathPatterns("/v1/members", "/v1/members/check-duplicate/**");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticationPrincipalArgumentResolver);
+        WebMvcConfigurer.super.addArgumentResolvers(resolvers);
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/auth/dto/request/AuthLoginRequest.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/auth/dto/request/AuthLoginRequest.java
@@ -12,9 +12,9 @@ import javax.validation.constraints.NotBlank;
 public class AuthLoginRequest {
 
     @Email(message = "1006:이메일 형식이 올바르지 않습니다.")
-    @NotBlank(message = "1012:공백일 수 없습니다.")
+    @NotBlank(message = "1005:공백일 수 없습니다.")
     private String email;
 
-    @NotBlank(message = "1012:공백일 수 없습니다.")
+    @NotBlank(message = "1005:공백일 수 없습니다.")
     private String password;
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/controller/MemberController.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/controller/MemberController.java
@@ -1,11 +1,14 @@
 package com.konkuk.Eodikase.domain.member.controller;
 
+import com.konkuk.Eodikase.domain.member.dto.MemberProfileUpdateRequest;
 import com.konkuk.Eodikase.domain.member.dto.request.MemberSignUpRequest;
 import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateEmailResponse;
 import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateNicknameResponse;
 import com.konkuk.Eodikase.domain.member.dto.response.MemberSignUpResponse;
 import com.konkuk.Eodikase.domain.member.service.MemberService;
+import com.konkuk.Eodikase.security.auth.LoginUserId;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -40,5 +43,16 @@ public class MemberController {
     public ResponseEntity<IsDuplicateNicknameResponse> checkDuplicateNickname(@RequestParam String value) {
         IsDuplicateNicknameResponse response = memberService.isDuplicateNickname(value);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "프로필 회원정보 수정")
+    @SecurityRequirement(name = "JWT")
+    @PutMapping(value = "/info")
+    public ResponseEntity<Void> updateProfileInfo(
+            @LoginUserId Long memberId,
+            @RequestBody @Valid MemberProfileUpdateRequest request
+    ) {
+        memberService.updateProfileInfo(memberId, request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/dto/MemberProfileUpdateRequest.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/dto/MemberProfileUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.konkuk.Eodikase.domain.member.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class MemberProfileUpdateRequest {
+
+    @NotBlank(message = "1005:공백일 수 없습니다.")
+    private String nickname;
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/member/entity/Member.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/entity/Member.java
@@ -5,6 +5,7 @@ import com.konkuk.Eodikase.domain.bookmark.entity.Bookmark;
 import com.konkuk.Eodikase.domain.comment.entity.Comment;
 import com.konkuk.Eodikase.domain.course.entity.Course;
 import com.konkuk.Eodikase.domain.review.entity.Review;
+import com.konkuk.Eodikase.exception.badrequest.InvalidNicknameException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 
 @Entity
@@ -19,6 +21,9 @@ import java.util.List;
 @Table(name = "member")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
+
+    private static final Pattern NICKNAME_REGEX = Pattern.compile("^[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣]{2,8}$");
+
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -55,11 +60,23 @@ public class Member extends BaseEntity {
     private MemberRole role;
 
     public Member(String email, String password, String nickname, MemberPlatform platform) {
+        validateNickname(nickname);
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.status = MemberStatus.MEMBER_ACTIVE;
         this.role = MemberRole.USER;
         this.platform = platform;
+    }
+
+    private void validateNickname(String nickname) {
+        if (!NICKNAME_REGEX.matcher(nickname).matches()) {
+            throw new InvalidNicknameException();
+        }
+    }
+
+    public void updateProfileInfo(String nickname) {
+        validateNickname(nickname);
+        this.nickname = nickname;
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
@@ -23,7 +23,6 @@ public class MemberService {
 
     private static final Pattern PASSWORD_REGEX = Pattern
             .compile("^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}");
-    private static final Pattern NICKNAME_REGEX = Pattern.compile("^[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣]{2,8}$");
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
@@ -43,6 +42,12 @@ public class MemberService {
             throw new DuplicateMemberException();
         }
         validateDuplicateNickname(memberSignUpRequest.getNickname());
+    }
+
+    private void validateNickname(String nickname) {
+        if (nickname.isBlank()) {
+            throw new InvalidNicknameException();
+        }
     }
 
     private void validateDuplicateNickname(String nickname) {
@@ -74,12 +79,6 @@ public class MemberService {
 
         boolean existsNickname = memberRepository.existsByNickname(nickname);
         return new IsDuplicateNicknameResponse(existsNickname);
-    }
-
-    private void validateNickname(String nickname) {
-        if (nickname.isBlank() || !NICKNAME_REGEX.matcher(nickname).matches()) {
-            throw new InvalidNicknameException();
-        }
     }
 
     @Transactional

--- a/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.konkuk.Eodikase.domain.member.service;
 
+import com.konkuk.Eodikase.domain.member.dto.MemberProfileUpdateRequest;
 import com.konkuk.Eodikase.domain.member.dto.request.MemberSignUpRequest;
 import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateEmailResponse;
 import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateNicknameResponse;
@@ -8,10 +9,12 @@ import com.konkuk.Eodikase.domain.member.entity.Member;
 import com.konkuk.Eodikase.domain.member.entity.MemberPlatform;
 import com.konkuk.Eodikase.domain.member.repository.MemberRepository;
 import com.konkuk.Eodikase.exception.badrequest.*;
+import com.konkuk.Eodikase.exception.notfound.NotFoundMemberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.util.regex.Pattern;
 
 @Service
@@ -77,5 +80,14 @@ public class MemberService {
         if (nickname.isBlank() || !NICKNAME_REGEX.matcher(nickname).matches()) {
             throw new InvalidNicknameException();
         }
+    }
+
+    @Transactional
+    public void updateProfileInfo(Long memberId, MemberProfileUpdateRequest request) {
+        String updateNickname = request.getNickname();
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+        validateDuplicateNickname(updateNickname);
+        member.updateProfileInfo(updateNickname);
     }
 }

--- a/src/test/java/com/konkuk/Eodikase/service/MemberServiceTest.java
+++ b/src/test/java/com/konkuk/Eodikase/service/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.konkuk.Eodikase.service;
 
+import com.konkuk.Eodikase.domain.member.dto.MemberProfileUpdateRequest;
 import com.konkuk.Eodikase.domain.member.dto.request.MemberSignUpRequest;
 import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateEmailResponse;
 import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateNicknameResponse;
@@ -21,6 +22,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @SpringBootTest
 public class MemberServiceTest {
@@ -164,5 +166,55 @@ public class MemberServiceTest {
         assertThatThrownBy(() -> memberService.signUp(new MemberSignUpRequest("dlawotn3@naver.com",
                 "edks1234!", nickname)))
                 .isInstanceOf(InvalidNicknameException.class);
+    }
+
+    @Test
+    @DisplayName("회원이 회원 정보를 수정하면 수정된 정보로 갱신된다")
+    void updateProfileInfo() {
+        String email = "dlawotn3@naver.com";
+        String password = "edks1234!";
+        String originalNickname = "감자";
+        String newNickname = "돌이";
+        Member member = new Member(email, passwordEncoder.encode(password), originalNickname, MemberPlatform.HOME);
+        memberRepository.save(member);
+
+        memberService.updateProfileInfo(member.getId(), new MemberProfileUpdateRequest(newNickname));
+        Member updatedMember = memberRepository.findById(member.getId())
+                .orElseThrow();
+
+        assertAll(
+                () -> assertThat(updatedMember.getNickname()).isEqualTo(newNickname)
+        );
+    }
+
+    @Test
+    @DisplayName("회원이 잘못된 닉네임 형식으로 회원정보 수정을 시도하면 예외를 반환한다")
+    void updateBadNicknameWithValidateException() {
+        String email = "dlawotn3@naver.com";
+        String password = "edks1234!";
+        String originalNickname = "감자";
+        String newNickname = "감";
+        Member member = new Member(email, passwordEncoder.encode(password), originalNickname, MemberPlatform.HOME);
+        memberRepository.save(member);
+
+        MemberProfileUpdateRequest request = new MemberProfileUpdateRequest(newNickname);
+        assertThatThrownBy(() -> memberService.updateProfileInfo(member.getId(), request))
+                .isInstanceOf(InvalidNicknameException.class);
+    }
+
+    @Test
+    @DisplayName("회원이 중복된 닉네임으로 회원정보 수정을 시도하면 예외를 반환한다")
+    void updateDuplicateNicknameWithValidateException() {
+        String email = "dlawotn3@naver.com";
+        String password = "edks1234!";
+        String originalNickname = "감자";
+        String newNickname = "돌이";
+        Member member = memberRepository.save(new Member(email, password, originalNickname, MemberPlatform.HOME));
+        memberRepository.save(new Member("dlawotn2@naver.com", "edks123!!!", "돌이",
+                MemberPlatform.HOME));
+
+        MemberProfileUpdateRequest request = new MemberProfileUpdateRequest(newNickname);
+        assertThatThrownBy(() -> memberService.updateProfileInfo(member.getId(), request))
+                .isInstanceOf(DuplicateNicknameException.class);
     }
 }


### PR DESCRIPTION
### 개요
회원정보(닉네임) 수정 API를 구현했습니다. 

### 작업사항
+ 회원정보 수정 API를 구현했습니다.
+ 회원정보 수정 관련 테스트 코드를 작성했습니다.

### 주의사항
+ 해당 기능부터는 로그인이 완료된 회원에 한해서만 해당 API를 사용할 수 있습니다. 로그인 토큰을 넣고 API를 호출해주세요.
  + **Swagser 예시** - 자물쇠 있는 API는 로그인한 회원만 접근 가능합니다
  <img width="909" alt="스크린샷 2023-07-24 오후 6 58 25" src="https://github.com/Eodikase/backend/assets/69844138/71c8b3e1-a17c-4b27-aed6-b8ca7357df95"> <img width="855" alt="스크린샷 2023-07-24 오후 6 58 41" src="https://github.com/Eodikase/backend/assets/69844138/9bd3b017-d0fa-4ed4-930a-842232050b91">

+ postman이나 swagger를 통해 해당 기능이 작동되는지, 관련 커스텀 예외가 잘 반환되는지 확인해주세요
+ 기획 로직과 다르게 구현된 부분이 있는지 확인해주세요
+ 오타가 있는지 확인해주세요