### PR TITLE
feat: OAuth 회원가입 POST API 구현

### DIFF
--- a/src/main/java/com/konkuk/Eodikase/domain/member/controller/MemberController.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/controller/MemberController.java
@@ -2,11 +2,9 @@ package com.konkuk.Eodikase.domain.member.controller;
 
 import com.konkuk.Eodikase.domain.member.dto.request.MemberProfileUpdateRequest;
 import com.konkuk.Eodikase.domain.member.dto.request.MemberSignUpRequest;
+import com.konkuk.Eodikase.domain.member.dto.request.OAuthMemberSignUpRequest;
 import com.konkuk.Eodikase.domain.member.dto.request.PasswordVerifyRequest;
-import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateEmailResponse;
-import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateNicknameResponse;
-import com.konkuk.Eodikase.domain.member.dto.response.MemberSignUpResponse;
-import com.konkuk.Eodikase.domain.member.dto.response.PasswordVerifyResponse;
+import com.konkuk.Eodikase.domain.member.dto.response.*;
 import com.konkuk.Eodikase.domain.member.service.MemberService;
 import com.konkuk.Eodikase.security.auth.LoginUserId;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,6 +28,13 @@ public class MemberController {
     @PostMapping
     public ResponseEntity<MemberSignUpResponse> signUp(@RequestBody @Valid MemberSignUpRequest request) {
         MemberSignUpResponse response = memberService.signUp(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "OAuth 회원가입")
+    @PostMapping("/oauth")
+    public ResponseEntity<OAuthMemberSignUpResponse> signUp(@RequestBody @Valid OAuthMemberSignUpRequest request) {
+        OAuthMemberSignUpResponse response = memberService.signUpByOAuthMember(request);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/konkuk/Eodikase/domain/member/dto/request/OAuthMemberSignUpRequest.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/dto/request/OAuthMemberSignUpRequest.java
@@ -1,0 +1,23 @@
+package com.konkuk.Eodikase.domain.member.dto.request;
+
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@ToString
+public class OAuthMemberSignUpRequest {
+
+    private String email;
+
+    @NotBlank(message = "1005:공백일 수 없습니다.")
+    private String nickname;
+
+    @NotBlank(message = "1005:공백일 수 없습니다.")
+    private String platform;
+
+    @NotBlank(message = "1005:공백일 수 없습니다.")
+    private String platformId;
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/member/dto/response/OAuthMemberSignUpResponse.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/dto/response/OAuthMemberSignUpResponse.java
@@ -1,0 +1,12 @@
+package com.konkuk.Eodikase.domain.member.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class OAuthMemberSignUpResponse {
+
+    private Long id;
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/member/entity/Member.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/entity/Member.java
@@ -33,7 +33,7 @@ public class Member extends BaseEntity {
     @Column(name = "email", nullable = false, length = 100)
     private String email;
 
-    @Column(name = "password", nullable = false, length = 100)
+    @Column(name = "password", length = 100)
     private String password;
 
     private String nickname;
@@ -56,6 +56,9 @@ public class Member extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private MemberPlatform platform;
 
+    @Column(name = "platform_id")
+    private String platformId;
+
     @Enumerated(value = EnumType.STRING)
     private MemberRole role;
 
@@ -67,6 +70,14 @@ public class Member extends BaseEntity {
         this.status = MemberStatus.MEMBER_ACTIVE;
         this.role = MemberRole.USER;
         this.platform = platform;
+        this.platformId = null;
+    }
+
+    public Member(String email, MemberPlatform platform, String platformId) {
+        this.email = email;
+        this.status = MemberStatus.MEMBER_ACTIVE;
+        this.platform = platform;
+        this.platformId = platformId;
     }
 
     public void registerOAuthMember(String email, String nickname) {

--- a/src/main/java/com/konkuk/Eodikase/domain/member/entity/Member.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/entity/Member.java
@@ -69,6 +69,14 @@ public class Member extends BaseEntity {
         this.platform = platform;
     }
 
+    public void registerOAuthMember(String email, String nickname) {
+        validateNickname(nickname);
+        this.nickname = nickname;
+        if (email != null) {
+            this.email = email;
+        }
+    }
+
     private void validateNickname(String nickname) {
         if (!NICKNAME_REGEX.matcher(nickname).matches()) {
             throw new InvalidNicknameException();

--- a/src/main/java/com/konkuk/Eodikase/domain/member/entity/MemberPlatform.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/entity/MemberPlatform.java
@@ -1,14 +1,28 @@
 package com.konkuk.Eodikase.domain.member.entity;
 
+import com.konkuk.Eodikase.exception.badrequest.InvalidMemberPlatformException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
 public enum MemberPlatform {
 
     HOME("HOME"),
     KAKAO("KAKAO"),
     GOOGLE("GOOGLE");
 
-    private final String value;
+    private String value;
 
-    MemberPlatform(final String value) {
-        this.value = value;
+    public static MemberPlatform from(String value) {
+        return Arrays.stream(values())
+                .filter(it -> Objects.equals(it.value, value))
+                .findFirst()
+                .orElseThrow(InvalidMemberPlatformException::new);
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/repository/MemberRepository.java
@@ -13,4 +13,6 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
     Boolean existsByNickname(String nickname);
 
     Optional<Member> findByEmailAndPlatform(String email, MemberPlatform platform);
+
+    Optional<Member> findByPlatformAndPlatformId(MemberPlatform platform, String platformId);
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
@@ -2,11 +2,9 @@ package com.konkuk.Eodikase.domain.member.service;
 
 import com.konkuk.Eodikase.domain.member.dto.request.MemberProfileUpdateRequest;
 import com.konkuk.Eodikase.domain.member.dto.request.MemberSignUpRequest;
+import com.konkuk.Eodikase.domain.member.dto.request.OAuthMemberSignUpRequest;
 import com.konkuk.Eodikase.domain.member.dto.request.PasswordVerifyRequest;
-import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateEmailResponse;
-import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateNicknameResponse;
-import com.konkuk.Eodikase.domain.member.dto.response.MemberSignUpResponse;
-import com.konkuk.Eodikase.domain.member.dto.response.PasswordVerifyResponse;
+import com.konkuk.Eodikase.domain.member.dto.response.*;
 import com.konkuk.Eodikase.domain.member.entity.Member;
 import com.konkuk.Eodikase.domain.member.entity.MemberPlatform;
 import com.konkuk.Eodikase.domain.member.repository.MemberRepository;
@@ -81,6 +79,16 @@ public class MemberService {
 
         boolean existsNickname = memberRepository.existsByNickname(nickname);
         return new IsDuplicateNicknameResponse(existsNickname);
+    }
+
+    @Transactional
+    public OAuthMemberSignUpResponse signUpByOAuthMember(OAuthMemberSignUpRequest request) {
+        MemberPlatform platform = MemberPlatform.from(request.getPlatform());
+        Member member = memberRepository.findByPlatformAndPlatformId(platform, request.getPlatformId())
+                .orElseThrow(NotFoundMemberException::new);
+
+        member.registerOAuthMember(request.getEmail(), request.getNickname());
+        return new OAuthMemberSignUpResponse(member.getId());
     }
 
     @Transactional

--- a/src/main/java/com/konkuk/Eodikase/exception/badrequest/InvalidMemberPlatformException.java
+++ b/src/main/java/com/konkuk/Eodikase/exception/badrequest/InvalidMemberPlatformException.java
@@ -1,0 +1,8 @@
+package com.konkuk.Eodikase.exception.badrequest;
+
+public class InvalidMemberPlatformException extends BadRequestException {
+
+    public InvalidMemberPlatformException() {
+        super("플랫폼 정보가 올바르지 않습니다.", 1012);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -13,6 +13,12 @@ spring:
         show_sql: true
         format_sql: true
 
+  h2:
+    console:
+      enabled: true
+      settings:
+        web-allow-others: true
+
 security.jwt.token:
   secret-key: testtesttesttesttesttesttesttesttesttest
   expire-length: 864000


### PR DESCRIPTION
### 개요
OAuth 회원가입 API를 구현했습니다. 
+ 카카오 및 구글 로그인은 따로 작업을 빼서 진행할 예정입니다.
+ 회원가입을 진행하지 않은 유저가 OAuth 로그인 시도 시, 먼저 회원가입 절차를 수행할 수 있도록 하는 API 입니다.

### 작업사항
+ OAuth 회원가입 API를 구현했습니다.
+ OAuth 회원가입 관련 테스트 코드를 작성했습니다.

### 주의사항
+ **Member Entity에 수정사항이 생겼습니다. (password nullable 옵션 false, platformId 컬럼 추가) DB에 해당 수정 사항을 반영하고 머지해야 합니다**
+ postman이나 swagger를 통해 해당 기능이 작동되는지, 관련 커스텀 예외가 잘 반환되는지 확인해주세요
+ 기획 로직과 다르게 구현된 부분이 있는지 확인해주세요
+ 오타가 있는지 확인해주세요