### PR TITLE
feat: 회원 탈퇴 논리적 삭제 구현

### DIFF
--- a/src/main/java/com/konkuk/Eodikase/config/BaseTimeConfig.java
+++ b/src/main/java/com/konkuk/Eodikase/config/BaseTimeConfig.java
@@ -1,0 +1,9 @@
+package com.konkuk.Eodikase.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class BaseTimeConfig {
+}

--- a/src/main/java/com/konkuk/Eodikase/config/BatchConfig.java
+++ b/src/main/java/com/konkuk/Eodikase/config/BatchConfig.java
@@ -1,0 +1,20 @@
+package com.konkuk.Eodikase.config;
+
+import com.konkuk.Eodikase.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@EnableScheduling
+@Configuration
+@RequiredArgsConstructor
+public class BatchConfig {
+
+    private final MemberService memberService;
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul") // 매일 자정에 실행
+    public void deleteMember() {
+        memberService.deleteMemberAfter30Days();
+    }
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/audit/BaseEntity.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/audit/BaseEntity.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
-import java.time.LocalDateTime;
+import java.sql.Timestamp;
 
 @Getter
 @MappedSuperclass
@@ -17,10 +17,9 @@ public class BaseEntity {
 
     @CreatedDate
     @Column(name = "created_date", updatable = false)
-    private LocalDateTime createdDate;
+    private Timestamp createdDate;
 
     @LastModifiedDate
     @Column(name = "modified_date")
-    private LocalDateTime modifiedDate;
-
+    private Timestamp modifiedDate;
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/auth/service/AuthService.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/auth/service/AuthService.java
@@ -4,9 +4,11 @@ import com.konkuk.Eodikase.domain.auth.dto.request.AuthLoginRequest;
 import com.konkuk.Eodikase.domain.auth.dto.response.TokenResponse;
 import com.konkuk.Eodikase.domain.member.entity.Member;
 import com.konkuk.Eodikase.domain.member.entity.MemberPlatform;
+import com.konkuk.Eodikase.domain.member.entity.MemberStatus;
 import com.konkuk.Eodikase.domain.member.repository.MemberRepository;
 import com.konkuk.Eodikase.exception.badrequest.PasswordMismatchException;
 import com.konkuk.Eodikase.exception.notfound.NotFoundMemberException;
+import com.konkuk.Eodikase.exception.unauthorized.InactiveMemberException;
 import com.konkuk.Eodikase.security.auth.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -24,6 +26,7 @@ public class AuthService {
         Member findMember = memberRepository.findByEmailAndPlatform(request.getEmail(), MemberPlatform.HOME)
                 .orElseThrow(NotFoundMemberException::new);
         validatePassword(findMember, request.getPassword());
+        validateStatus(findMember);
 
         String token = issueToken(findMember);
         return TokenResponse.from(token);
@@ -36,6 +39,12 @@ public class AuthService {
     private void validatePassword(final Member findMember, final String password) {
         if (!passwordEncoder.matches(password, findMember.getPassword())) {
             throw new PasswordMismatchException();
+        }
+    }
+
+    private void validateStatus(final Member member) {
+        if (member.getStatus() != MemberStatus.MEMBER_ACTIVE) {
+            throw new InactiveMemberException();
         }
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/controller/MemberController.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/controller/MemberController.java
@@ -98,4 +98,12 @@ public class MemberController {
         PasswordVerifyResponse response = memberService.verifyPassword(memberId, request);
         return ResponseEntity.ok(response);
     }
+
+    @Operation(summary = "회원 탈퇴")
+    @SecurityRequirement(name = "JWT")
+    @DeleteMapping
+    public ResponseEntity<Void> delete(@LoginUserId Long memberId) {
+        memberService.delete(memberId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/entity/Member.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/entity/Member.java
@@ -6,6 +6,7 @@ import com.konkuk.Eodikase.domain.comment.entity.Comment;
 import com.konkuk.Eodikase.domain.course.entity.Course;
 import com.konkuk.Eodikase.domain.review.entity.Review;
 import com.konkuk.Eodikase.exception.badrequest.InvalidNicknameException;
+import com.konkuk.Eodikase.exception.unauthorized.InactiveMemberException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/konkuk/Eodikase/domain/member/entity/Member.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/entity/Member.java
@@ -102,4 +102,9 @@ public class Member extends BaseEntity {
         validateNickname(nickname);
         this.nickname = nickname;
     }
+
+    public void deleteMemberInfo() {
+        this.status = MemberStatus.MEMBER_QUIT;
+        //TODO: 프로필 이미지 null 처리
+    }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/entity/Member.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/entity/Member.java
@@ -73,6 +73,18 @@ public class Member extends BaseEntity {
         this.platformId = null;
     }
 
+    public Member(String email, String password, String nickname,
+                  MemberPlatform platform, String platformId, MemberStatus status) {
+        validateNickname(nickname);
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.platform = platform;
+        this.role = MemberRole.USER;
+        this.platformId = platformId;
+        this.status = status;
+    }
+
     public Member(String email, MemberPlatform platform, String platformId) {
         this.email = email;
         this.status = MemberStatus.MEMBER_ACTIVE;

--- a/src/main/java/com/konkuk/Eodikase/domain/member/entity/Member.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/entity/Member.java
@@ -24,7 +24,6 @@ public class Member extends BaseEntity {
 
     private static final Pattern NICKNAME_REGEX = Pattern.compile("^[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣]{2,8}$");
 
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="member_id")

--- a/src/main/java/com/konkuk/Eodikase/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/repository/MemberRepository.java
@@ -21,7 +21,7 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
 
     Optional<Member> findByPlatformAndPlatformId(MemberPlatform platform, String platformId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from Member m where m.modifiedDate <= :thresholdDate and m.status = :status")
     void deleteMemberByCreatedTime(@Param("thresholdDate") Date thresholdDate, @Param("status") MemberStatus status);
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/repository/MemberRepository.java
@@ -2,6 +2,7 @@ package com.konkuk.Eodikase.domain.member.repository;
 
 import com.konkuk.Eodikase.domain.member.entity.Member;
 import com.konkuk.Eodikase.domain.member.entity.MemberPlatform;
+import com.konkuk.Eodikase.domain.member.entity.MemberStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -21,6 +22,6 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
     Optional<Member> findByPlatformAndPlatformId(MemberPlatform platform, String platformId);
 
     @Modifying
-    @Query("delete from Member m where m.modifiedDate <= :thresholdDate")
-    void deleteMemberByCreatedTime(@Param("thresholdDate") Date thresholdDate);
+    @Query("delete from Member m where m.modifiedDate <= :thresholdDate and m.status = :status")
+    void deleteMemberByCreatedTime(@Param("thresholdDate") Date thresholdDate, @Param("status") MemberStatus status);
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/repository/MemberRepository.java
@@ -3,7 +3,11 @@ package com.konkuk.Eodikase.domain.member.repository;
 import com.konkuk.Eodikase.domain.member.entity.Member;
 import com.konkuk.Eodikase.domain.member.entity.MemberPlatform;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Date;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member,Long> {
@@ -15,4 +19,8 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
     Optional<Member> findByEmailAndPlatform(String email, MemberPlatform platform);
 
     Optional<Member> findByPlatformAndPlatformId(MemberPlatform platform, String platformId);
+
+    @Modifying
+    @Query("delete from Member m where m.modifiedDate <= :thresholdDate")
+    void deleteMemberByCreatedTime(@Param("thresholdDate") Date thresholdDate);
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
@@ -129,4 +129,11 @@ public class MemberService {
 
         return new GetUpdateProfileInfoResponse(member.getEmail(), member.getNickname());
     }
+
+    @Transactional
+    public void delete(Long memberId) {
+        Member findMember = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+        findMember.deleteMemberInfo();
+    }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
@@ -11,6 +11,7 @@ import com.konkuk.Eodikase.domain.member.dto.request.PasswordVerifyRequest;
 import com.konkuk.Eodikase.domain.member.dto.response.*;
 import com.konkuk.Eodikase.domain.member.entity.Member;
 import com.konkuk.Eodikase.domain.member.entity.MemberPlatform;
+import com.konkuk.Eodikase.domain.member.entity.MemberStatus;
 import com.konkuk.Eodikase.domain.member.repository.MemberRepository;
 import com.konkuk.Eodikase.exception.badrequest.*;
 import com.konkuk.Eodikase.exception.notfound.NotFoundMemberException;
@@ -146,6 +147,6 @@ public class MemberService {
         LocalDate thresholdLocalDate = LocalDate.now().minusDays(30);
         Instant instant = thresholdLocalDate.atStartOfDay(ZoneId.systemDefault()).toInstant();
         Date thresholdDate = Date.from(instant);
-        memberRepository.deleteMemberByCreatedTime(thresholdDate);
+        memberRepository.deleteMemberByCreatedTime(thresholdDate, MemberStatus.MEMBER_QUIT);
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/service/MemberService.java
@@ -19,6 +19,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.regex.Pattern;
 
 @Service
@@ -135,5 +139,13 @@ public class MemberService {
         Member findMember = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         findMember.deleteMemberInfo();
+    }
+
+    @Transactional
+    public void deleteMemberAfter30Days() {
+        LocalDate thresholdLocalDate = LocalDate.now().minusDays(30);
+        Instant instant = thresholdLocalDate.atStartOfDay(ZoneId.systemDefault()).toInstant();
+        Date thresholdDate = Date.from(instant);
+        memberRepository.deleteMemberByCreatedTime(thresholdDate);
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/exception/unauthorized/InactiveMemberException.java
+++ b/src/main/java/com/konkuk/Eodikase/exception/unauthorized/InactiveMemberException.java
@@ -1,0 +1,8 @@
+package com.konkuk.Eodikase.exception.unauthorized;
+
+public class InactiveMemberException extends UnauthorizedException {
+
+    public InactiveMemberException() {
+        super("서비스에 접근할 수 없는 회원입니다.", 1013);
+    }
+}

--- a/src/test/java/com/konkuk/Eodikase/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/konkuk/Eodikase/repository/MemberRepositoryTest.java
@@ -1,0 +1,44 @@
+package com.konkuk.Eodikase.repository;
+
+import com.konkuk.Eodikase.domain.member.entity.Member;
+import com.konkuk.Eodikase.domain.member.entity.MemberPlatform;
+import com.konkuk.Eodikase.domain.member.entity.MemberStatus;
+import com.konkuk.Eodikase.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RepositoryTest
+public class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("회원이 Member_Quit 이 된지 thresholdDate 만큼 지났으면 모두 삭제한다.")
+    void deleteDeletedMemberByCreatedTime() {
+        Member member1 = new Member("dlawotn3@naver.com", "jisu0708!", "메리",
+                MemberPlatform.HOME, null, MemberStatus.MEMBER_QUIT);
+        Member member2 = new Member("dlawotn2@naver.com", "jisu0708!", "메이",
+                MemberPlatform.HOME, null, MemberStatus.MEMBER_QUIT);
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+
+        LocalDate thresholdDateTime = LocalDate.now().plusDays(1);
+        Instant instant = thresholdDateTime.atStartOfDay(ZoneId.systemDefault()).toInstant();
+        Date thresholdDate = Date.from(instant);
+        memberRepository.deleteMemberByCreatedTime(thresholdDate, MemberStatus.MEMBER_QUIT);
+
+        List<Member> actual = memberRepository.findAll();
+
+        assertThat(actual).hasSize(0);
+    }
+}

--- a/src/test/java/com/konkuk/Eodikase/repository/RepositoryTest.java
+++ b/src/test/java/com/konkuk/Eodikase/repository/RepositoryTest.java
@@ -1,0 +1,17 @@
+package com.konkuk.Eodikase.repository;
+
+import com.konkuk.Eodikase.config.BaseTimeConfig;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@DataJpaTest
+@Import(BaseTimeConfig.class)
+public @interface RepositoryTest {
+}

--- a/src/test/java/com/konkuk/Eodikase/service/AuthServiceTest.java
+++ b/src/test/java/com/konkuk/Eodikase/service/AuthServiceTest.java
@@ -5,8 +5,10 @@ import com.konkuk.Eodikase.domain.auth.dto.response.TokenResponse;
 import com.konkuk.Eodikase.domain.auth.service.AuthService;
 import com.konkuk.Eodikase.domain.member.entity.Member;
 import com.konkuk.Eodikase.domain.member.entity.MemberPlatform;
+import com.konkuk.Eodikase.domain.member.entity.MemberStatus;
 import com.konkuk.Eodikase.domain.member.repository.MemberRepository;
 import com.konkuk.Eodikase.exception.badrequest.PasswordMismatchException;
+import com.konkuk.Eodikase.exception.unauthorized.InactiveMemberException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SpringBootTest
+@ServiceTest
 class AuthServiceTest {
 
     @Autowired
@@ -59,6 +61,21 @@ class AuthServiceTest {
         AuthLoginRequest loginRequest = new AuthLoginRequest(email, "wrongPassword");
 
         assertThrows(PasswordMismatchException.class,
+                () -> authService.login(loginRequest));
+    }
+
+    @Test
+    @DisplayName("status가 QUIT인 회원이 자체 로그인 시도할 시 예외를 반환한다")
+    void loginWithQuitStatus() {
+        String email = "dlawotn3@naver.com";
+        String password = "edks123!";
+        String encodedPassword = passwordEncoder.encode(password);
+        Member member = new Member("dlawotn3@naver.com", encodedPassword, "메리", MemberPlatform.HOME,
+                null, MemberStatus.MEMBER_QUIT);
+        memberRepository.save(member);
+        AuthLoginRequest loginRequest = new AuthLoginRequest(email, password);
+
+        assertThrows(InactiveMemberException.class,
                 () -> authService.login(loginRequest));
     }
 }

--- a/src/test/java/com/konkuk/Eodikase/service/MemberServiceTest.java
+++ b/src/test/java/com/konkuk/Eodikase/service/MemberServiceTest.java
@@ -11,6 +11,7 @@ import com.konkuk.Eodikase.domain.member.dto.response.IsDuplicateNicknameRespons
 import com.konkuk.Eodikase.domain.member.dto.response.PasswordVerifyResponse;
 import com.konkuk.Eodikase.domain.member.entity.Member;
 import com.konkuk.Eodikase.domain.member.entity.MemberPlatform;
+import com.konkuk.Eodikase.domain.member.entity.MemberStatus;
 import com.konkuk.Eodikase.domain.member.repository.MemberRepository;
 import com.konkuk.Eodikase.domain.member.service.MemberService;
 import com.konkuk.Eodikase.exception.badrequest.*;
@@ -25,12 +26,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-@SpringBootTest
+@ServiceTest
 public class MemberServiceTest {
 
     @Autowired
@@ -322,5 +324,20 @@ public class MemberServiceTest {
                 () -> assertThat(actual.getEmail()).isEqualTo(email),
                 () -> assertThat(actual.getNickname()).isEqualTo(nickname)
         );
+    }
+
+    @Test
+    @DisplayName("회원을 정상적으로 탈퇴한다")
+    void deleteMember() {
+        String email = "dlawotn3@naver.com";
+        String password = "edks1234!";
+        String nickname = "감자";
+        Member member = new Member(email, passwordEncoder.encode(password), nickname, MemberPlatform.HOME);
+        memberRepository.save(member);
+
+        memberService.delete(member.getId());
+
+        Optional<Member> findMember = memberRepository.findById(member.getId());
+        assertThat(findMember.get().getStatus()).isEqualTo(MemberStatus.MEMBER_QUIT);
     }
 }

--- a/src/test/java/com/konkuk/Eodikase/service/ServiceTest.java
+++ b/src/test/java/com/konkuk/Eodikase/service/ServiceTest.java
@@ -1,0 +1,14 @@
+package com.konkuk.Eodikase.service;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public @interface ServiceTest {
+}


### PR DESCRIPTION
### 개요
회원 탈퇴 논리적 삭제를 구현했습니다. 자세한 로직은 다음과 같습니다.

회원 탈퇴 -> Member 테이블에서 프로필 이미지 null 처리 후(도입 예정), status를 quit으로 변경 -> 매 자정마다 status가 quit이 된 지 30일 이상된 회원을 물리적 삭제 처리

### 작업사항
+ BaseTime 관련 설정을 수정했습니다
+ 회원 탈퇴 논리적 삭제 로직 구현했습니다
  + 프로필 이미지 null 처리(도입 예정) 및 status를 quit으로 변경
  + status가 quit인 경우, 서비스 이용 제한 로직 추가
+ 스케줄링 작업으로 물리적 삭제 로직 구현했습니다
+ 회원 탈퇴 및 스케줄링 관련 테스트 코드 작성했습니다

### 주의사항
+ 해당 코드는 매 자정마다 quit이 된 지 30일 된 회원을 스케줄링 작업으로 물리적 삭제를 가하는 코드입니다. 로컬에서 테스트 할 시, 적절한 값으로 변경하여 테스트해야 합니다.
+ postman이나 swagger를 통해 해당 기능이 작동되는지, 관련 커스텀 예외가 잘 반환되는지 확인해주세요
+ 기획 로직과 다르게 구현된 부분이 있는지 확인해주세요
+ 오타가 있는지 확인해주세요