### PR TITLE
feat: 지역/타입별 추천 코스 아이템 조회 GET API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'com.slack.api:slack-api-client:1.29.0'
 	implementation platform("org.springframework.cloud:spring-cloud-dependencies:2021.0.5")
 	implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
+	implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '5.6.15.Final'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/konkuk/Eodikase/EodikaseApplication.java
+++ b/src/main/java/com/konkuk/Eodikase/EodikaseApplication.java
@@ -8,5 +8,7 @@ public class EodikaseApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(EodikaseApplication.class, args);
+
 	}
+
 }

--- a/src/main/java/com/konkuk/Eodikase/TestController.java
+++ b/src/main/java/com/konkuk/Eodikase/TestController.java
@@ -9,6 +9,8 @@ public class TestController {
 
     @GetMapping("/test")
     public String test(){
-        return "yml 관련 서브모듈 브랜치 업데이트";
+        System.out.println(org.hibernate.Version.getVersionString());
+        return "yml 관련 서브모듈 브랜치 업데이트 ";
+
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/config/AuthConfig.java
+++ b/src/main/java/com/konkuk/Eodikase/config/AuthConfig.java
@@ -21,6 +21,7 @@ public class AuthConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(loginInterceptor)
                 .addPathPatterns("/v1/members/**")
+                .addPathPatterns("/v1/courseDatas/**")
                 .excludePathPatterns("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs", "/error")
                 .excludePathPatterns("/v1/members", "/v1/members/oauth", "/v1/members/check-duplicate/**");
     }

--- a/src/main/java/com/konkuk/Eodikase/domain/audit/BaseCourseEntity.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/audit/BaseCourseEntity.java
@@ -1,6 +1,8 @@
 package com.konkuk.Eodikase.domain.audit;
 
 import lombok.Getter;
+
+import org.locationtech.jts.geom.Point;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
@@ -34,4 +36,5 @@ public abstract class BaseCourseEntity {
 
     private String img3;
 
+    private Point point;
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/audit/BaseCourseEntity.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/audit/BaseCourseEntity.java
@@ -11,8 +11,8 @@ import javax.persistence.*;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 public abstract class BaseCourseEntity {
+
     private String name;
 
     private String category;

--- a/src/main/java/com/konkuk/Eodikase/domain/audit/BaseCourseEntity.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/audit/BaseCourseEntity.java
@@ -36,5 +36,11 @@ public abstract class BaseCourseEntity {
 
     private String img3;
 
+    private double lat;
+
+    private double lng;
+
+    private String addr;
+
     private Point point;
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/audit/BaseCourseEntity.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/audit/BaseCourseEntity.java
@@ -11,6 +11,7 @@ import javax.persistence.*;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 public abstract class BaseCourseEntity {
     private String name;
 

--- a/src/main/java/com/konkuk/Eodikase/domain/data/controller/CourseDataController.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/controller/CourseDataController.java
@@ -3,11 +3,25 @@ package com.konkuk.Eodikase.domain.data.controller;
 import com.konkuk.Eodikase.domain.data.service.CourseDataService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/v1/courseDatas")
 public class CourseDataController {
 
     private final CourseDataService courseDataService;
 
+    @Operation(summary = "타입별 코스 아이템 조회")
+    @GetMapping
+    public ResponseEntity<GetFilteredCourseDataResponse> getFilteredCourseData(
+            @RequestParam String region, @RequestParam String types
+    ) {
+        GetFilteredCourseDataResponse response = courseDataService.getFilteredCourseData(region, types);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/controller/CourseDataController.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/controller/CourseDataController.java
@@ -20,9 +20,9 @@ public class CourseDataController {
     @Operation(summary = "타입별 코스 아이템 조회")
     @GetMapping
     public ResponseEntity<GetFilteredCourseDataResponse> getFilteredCourseData(
-            @RequestParam String region, @RequestParam String types, @RequestParam String order
+            @RequestParam String region, @RequestParam String category, @RequestParam String order
     ) {
-        GetFilteredCourseDataResponse response = courseDataService.filtersCourseDataByType(region, types, order);
+        GetFilteredCourseDataResponse response = courseDataService.filtersCourseDataByType(region, category, order);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/controller/CourseDataController.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/controller/CourseDataController.java
@@ -1,14 +1,14 @@
 package com.konkuk.Eodikase.domain.data.controller;
 
-import com.konkuk.Eodikase.domain.data.dto.response.GetFilteredCourseDataResponse;
+import com.konkuk.Eodikase.domain.data.dto.request.FilteredCourseDataRequest;
+import com.konkuk.Eodikase.domain.data.dto.response.FilteredCourseDataResponse;
 import com.konkuk.Eodikase.domain.data.service.CourseDataService;
+import com.konkuk.Eodikase.security.auth.LoginUserId;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,11 +18,19 @@ public class CourseDataController {
     private final CourseDataService courseDataService;
 
     @Operation(summary = "타입별 코스 아이템 조회")
-    @GetMapping
-    public ResponseEntity<GetFilteredCourseDataResponse> getFilteredCourseData(
-            @RequestParam String region, @RequestParam String category, @RequestParam String order
+    @SecurityRequirement(name = "JWT")
+    @GetMapping("/first")
+    public ResponseEntity<FilteredCourseDataResponse> getFilteredCourseData(
+            @LoginUserId Long memberId,
+            @RequestParam String region,
+            @RequestParam String type,
+            @RequestParam int stage,
+            @RequestParam("page") final Integer page,
+            @RequestParam("count") final int count,
+            @RequestBody FilteredCourseDataRequest request
     ) {
-        GetFilteredCourseDataResponse response = courseDataService.filtersCourseDataByType(region, category, order);
+        FilteredCourseDataResponse response = courseDataService.filtersCourseData(
+                memberId, region, type, stage, request, page, count);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/controller/CourseDataController.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/controller/CourseDataController.java
@@ -1,13 +1,14 @@
 package com.konkuk.Eodikase.domain.data.controller;
 
+import com.konkuk.Eodikase.domain.data.dto.response.GetFilteredCourseDataResponse;
 import com.konkuk.Eodikase.domain.data.service.CourseDataService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,7 +22,7 @@ public class CourseDataController {
     public ResponseEntity<GetFilteredCourseDataResponse> getFilteredCourseData(
             @RequestParam String region, @RequestParam String types
     ) {
-        GetFilteredCourseDataResponse response = courseDataService.getFilteredCourseData(region, types);
+        GetFilteredCourseDataResponse response = courseDataService.filtersCourseDataByType(region, types);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/controller/CourseDataController.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/controller/CourseDataController.java
@@ -29,7 +29,7 @@ public class CourseDataController {
             @RequestParam("count") final int count,
             @RequestBody FilteredCourseDataRequest request
     ) {
-        FilteredCourseDataResponse response = courseDataService.filtersCourseData(
+        FilteredCourseDataResponse response = courseDataService.filtersFirstCourseData(
                 memberId, region, type, stage, request, page, count);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/controller/CourseDataController.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/controller/CourseDataController.java
@@ -25,12 +25,11 @@ public class CourseDataController {
             @RequestParam String region,
             @RequestParam String type,
             @RequestParam int stage,
-            @RequestParam("page") final Integer page,
-            @RequestParam("count") final int count,
+            @RequestParam int order,
             @RequestBody FilteredCourseDataRequest request
     ) {
-        FilteredCourseDataResponse response = courseDataService.filtersFirstCourseData(
-                memberId, region, type, stage, request, page, count);
+        FilteredCourseDataResponse response = courseDataService.filtersCourseData(
+                memberId, region, type, stage, order, request);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/controller/CourseDataController.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/controller/CourseDataController.java
@@ -19,17 +19,19 @@ public class CourseDataController {
 
     @Operation(summary = "타입별 코스 아이템 조회")
     @SecurityRequirement(name = "JWT")
-    @GetMapping("/first")
+    @GetMapping
     public ResponseEntity<FilteredCourseDataResponse> getFilteredCourseData(
             @LoginUserId Long memberId,
             @RequestParam String region,
             @RequestParam String type,
             @RequestParam int stage,
             @RequestParam int order,
+            @RequestParam("page") final Integer page,
+            @RequestParam("count") final int count,
             @RequestBody FilteredCourseDataRequest request
     ) {
         FilteredCourseDataResponse response = courseDataService.filtersCourseData(
-                memberId, region, type, stage, order, request);
+                memberId, region, type, stage, order, request, page, count);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/dto/request/FilteredCourseDataRequest.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/dto/request/FilteredCourseDataRequest.java
@@ -1,0 +1,11 @@
+package com.konkuk.Eodikase.domain.data.dto.request;
+
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class FilteredCourseDataRequest {
+    private double lat;
+    private double lng;
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/dto/response/CourseDataPreviewInfoResponse.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/dto/response/CourseDataPreviewInfoResponse.java
@@ -1,0 +1,14 @@
+package com.konkuk.Eodikase.domain.data.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class CourseDataPreviewInfoResponse {
+    private Long dataId;
+    private String dataName;
+    private String dataCategory;
+    private String dataOperatingTime;
+    private String dataLocation;
+    private String dataPhoneNumber;
+    private String dataImageUrl;
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/dto/response/FilteredCourseDataByRadiusResponse.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/dto/response/FilteredCourseDataByRadiusResponse.java
@@ -1,0 +1,69 @@
+package com.konkuk.Eodikase.domain.data.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class FilteredCourseDataByRadiusResponse {
+
+    private Long id;
+
+    private String name;
+
+    private String category;
+
+    private String location;
+
+    private String phoneNumber;
+
+    private Float scoreByNaver;
+
+    private String href;
+
+    private String operatingTime;
+
+    private int reviewCount;
+
+    private String imageUrl;
+
+    private String img1;
+
+    private String img2;
+
+    private String img3;
+
+    private double lat;
+
+    private double lng;
+
+    private String addr;
+
+    private Point point;
+
+    public FilteredCourseDataByRadiusResponse(
+            Long id, String name, String category, String location, String phoneNumber, Float scoreByNaver, String href,
+            String operatingTime, int reviewCount, String imageUrl, String img1, String img2, String img3,
+            double lat, double lng, String addr, Point point
+            ) {
+        this.id = id;
+        this.name = name;
+        this.category = category;
+        this.location = location;
+        this.phoneNumber = phoneNumber;
+        this.scoreByNaver = scoreByNaver;
+        this.href = href;
+        this.operatingTime = operatingTime;
+        this.reviewCount = reviewCount;
+        this.imageUrl = imageUrl;
+        this.img1 = img1;
+        this.img2 = img2;
+        this.img3 = img3;
+        this.lat = lat;
+        this.lng = lng;
+        this.addr = addr;
+        this.point = point;
+    }
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/dto/response/FilteredCourseDataByRadiusResponse.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/dto/response/FilteredCourseDataByRadiusResponse.java
@@ -3,7 +3,6 @@ package com.konkuk.Eodikase.domain.data.dto.response;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.locationtech.jts.geom.Point;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -21,49 +20,30 @@ public class FilteredCourseDataByRadiusResponse {
 
     private Float scoreByNaver;
 
-    private String href;
-
     private String operatingTime;
 
     private int reviewCount;
 
     private String imageUrl;
 
-    private String img1;
-
-    private String img2;
-
-    private String img3;
-
     private double lat;
 
     private double lng;
 
-    private String addr;
-
-    private Point point;
-
     public FilteredCourseDataByRadiusResponse(
-            Long id, String name, String category, String location, String phoneNumber, Float scoreByNaver, String href,
-            String operatingTime, int reviewCount, String imageUrl, String img1, String img2, String img3,
-            double lat, double lng, String addr, Point point
-            ) {
+            Long id, String name, String category, String location, String phoneNumber, Float scoreByNaver,
+            String operatingTime, int reviewCount, String imageUrl, double lat, double lng
+    ) {
         this.id = id;
         this.name = name;
         this.category = category;
         this.location = location;
         this.phoneNumber = phoneNumber;
         this.scoreByNaver = scoreByNaver;
-        this.href = href;
         this.operatingTime = operatingTime;
         this.reviewCount = reviewCount;
         this.imageUrl = imageUrl;
-        this.img1 = img1;
-        this.img2 = img2;
-        this.img3 = img3;
         this.lat = lat;
         this.lng = lng;
-        this.addr = addr;
-        this.point = point;
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/dto/response/FilteredCourseDataByRegionAndTypeResponse.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/dto/response/FilteredCourseDataByRegionAndTypeResponse.java
@@ -1,0 +1,67 @@
+package com.konkuk.Eodikase.domain.data.dto.response;
+
+import lombok.*;
+import org.locationtech.jts.geom.Point;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class FilteredCourseDataByRegionAndTypeResponse {
+
+    private Long id;
+
+    private String name;
+
+    private String category;
+
+    private String location;
+
+    private String phoneNumber;
+
+    private Float scoreByNaver;
+
+    private String href;
+
+    private String operatingTime;
+
+    private int reviewCount;
+
+    private String imageUrl;
+
+    private String img1;
+
+    private String img2;
+
+    private String img3;
+
+    private double lat;
+
+    private double lng;
+
+    private String addr;
+
+    private Point point;
+
+    public FilteredCourseDataByRegionAndTypeResponse(
+            Long id, String name, String category, String location, String phoneNumber, Float scoreByNaver, String href,
+            String operatingTime, int reviewCount, String imageUrl, String img1, String img2, String img3,
+            double lat, double lng, String addr, Point point
+            ) {
+        this.id = id;
+        this.name = name;
+        this.category = category;
+        this.location = location;
+        this.phoneNumber = phoneNumber;
+        this.scoreByNaver = scoreByNaver;
+        this.href = href;
+        this.operatingTime = operatingTime;
+        this.reviewCount = reviewCount;
+        this.imageUrl = imageUrl;
+        this.img1 = img1;
+        this.img2 = img2;
+        this.img3 = img3;
+        this.lat = lat;
+        this.lng = lng;
+        this.addr = addr;
+        this.point = point;
+    }
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/dto/response/FilteredCourseDataByRegionAndTypeResponse.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/dto/response/FilteredCourseDataByRegionAndTypeResponse.java
@@ -1,7 +1,8 @@
 package com.konkuk.Eodikase.domain.data.dto.response;
 
-import lombok.*;
-import org.locationtech.jts.geom.Point;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -19,49 +20,30 @@ public class FilteredCourseDataByRegionAndTypeResponse {
 
     private Float scoreByNaver;
 
-    private String href;
-
     private String operatingTime;
 
     private int reviewCount;
 
     private String imageUrl;
 
-    private String img1;
-
-    private String img2;
-
-    private String img3;
-
     private double lat;
 
     private double lng;
 
-    private String addr;
-
-    private Point point;
-
     public FilteredCourseDataByRegionAndTypeResponse(
-            Long id, String name, String category, String location, String phoneNumber, Float scoreByNaver, String href,
-            String operatingTime, int reviewCount, String imageUrl, String img1, String img2, String img3,
-            double lat, double lng, String addr, Point point
-            ) {
+            Long id, String name, String category, String location, String phoneNumber, Float scoreByNaver,
+            String operatingTime, int reviewCount, String imageUrl, double lat, double lng
+    ) {
         this.id = id;
         this.name = name;
         this.category = category;
         this.location = location;
         this.phoneNumber = phoneNumber;
         this.scoreByNaver = scoreByNaver;
-        this.href = href;
         this.operatingTime = operatingTime;
         this.reviewCount = reviewCount;
         this.imageUrl = imageUrl;
-        this.img1 = img1;
-        this.img2 = img2;
-        this.img3 = img3;
         this.lat = lat;
         this.lng = lng;
-        this.addr = addr;
-        this.point = point;
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/dto/response/FilteredCourseDataResponse.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/dto/response/FilteredCourseDataResponse.java
@@ -1,0 +1,16 @@
+package com.konkuk.Eodikase.domain.data.dto.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class FilteredCourseDataResponse {
+    private String datasType;
+    private List<FilteredCourseDataByRadiusResponse> datas;
+
+    public FilteredCourseDataResponse(String datasType, List<FilteredCourseDataByRadiusResponse> datas) {
+        this.datasType = datasType;
+        this.datas = datas;
+    }
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/dto/response/GetFilteredCourseDataResponse.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/dto/response/GetFilteredCourseDataResponse.java
@@ -1,7 +1,0 @@
-package com.konkuk.Eodikase.domain.data.dto.response;
-
-import java.util.List;
-
-public class GetFilteredCourseDataResponse {
-    private List<Long> dataIds;
-}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/dto/response/GetFilteredCourseDataResponse.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/dto/response/GetFilteredCourseDataResponse.java
@@ -1,0 +1,7 @@
+package com.konkuk.Eodikase.domain.data.dto.response;
+
+import java.util.List;
+
+public class GetFilteredCourseDataResponse {
+    private List<Long> dataIds;
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/entity/CourseDataCategory.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/entity/CourseDataCategory.java
@@ -1,15 +1,28 @@
 package com.konkuk.Eodikase.domain.data.entity;
 
+import com.konkuk.Eodikase.exception.badrequest.InvalidCourseDataCategoryException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
 public enum CourseDataCategory {
     CAFE("CAFE"),
     RES("RES"),
     ACT("ACT");
 
-    private final String category;
+    private String value;
 
-
-    CourseDataCategory(final String category) {
-        this.category = category;
+    public static CourseDataCategory from(String value) {
+        return Arrays.stream(values())
+                .filter(it -> Objects.equals(it.value, value))
+                .findFirst()
+                .orElseThrow(InvalidCourseDataCategoryException::new);
     }
 
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/entity/CourseDataEM.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/entity/CourseDataEM.java
@@ -3,7 +3,6 @@ package com.konkuk.Eodikase.domain.data.entity;
 import com.konkuk.Eodikase.domain.audit.BaseCourseEntity;
 import com.konkuk.Eodikase.domain.course.entity.CourseCourseDataRel;
 import lombok.Getter;
-import lombok.Setter;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -17,7 +16,7 @@ public class CourseDataEM extends BaseCourseEntity {
     private Long id;
 
     @Enumerated(value = EnumType.STRING)
-    private CourseDataCategory CourseDataCategory;
+    private CourseDataCategory courseDataCategory;
 
     @OneToMany(mappedBy = "courseDataEM")
     private List<CourseCourseDataRel> courseDataList = new ArrayList<>();

--- a/src/main/java/com/konkuk/Eodikase/domain/data/entity/CourseDataHI.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/entity/CourseDataHI.java
@@ -3,7 +3,6 @@ package com.konkuk.Eodikase.domain.data.entity;
 import com.konkuk.Eodikase.domain.audit.BaseCourseEntity;
 import com.konkuk.Eodikase.domain.course.entity.CourseCourseDataRel;
 import lombok.Getter;
-import lombok.Setter;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -17,7 +16,7 @@ public class CourseDataHI extends BaseCourseEntity {
     private Long id;
 
     @Enumerated(value = EnumType.STRING)
-    private CourseDataCategory CourseDataCategory;
+    private CourseDataCategory courseDataCategory;
 
     @OneToMany(mappedBy = "courseDataHI")
     private List<CourseCourseDataRel> courseDataList = new ArrayList<>();

--- a/src/main/java/com/konkuk/Eodikase/domain/data/entity/CourseDataHSE.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/entity/CourseDataHSE.java
@@ -3,7 +3,6 @@ package com.konkuk.Eodikase.domain.data.entity;
 import com.konkuk.Eodikase.domain.audit.BaseCourseEntity;
 import com.konkuk.Eodikase.domain.course.entity.CourseCourseDataRel;
 import lombok.Getter;
-import lombok.Setter;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -17,7 +16,7 @@ public class CourseDataHSE extends BaseCourseEntity {
     private Long id;
 
     @Enumerated(value = EnumType.STRING)
-    private CourseDataCategory CourseDataCategory;
+    private CourseDataCategory courseDataCategory;
 
     @OneToMany(mappedBy = "courseDataHSE")
     private List<CourseCourseDataRel> courseDataList = new ArrayList<>();

--- a/src/main/java/com/konkuk/Eodikase/domain/data/entity/CourseDataKSS.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/entity/CourseDataKSS.java
@@ -17,7 +17,7 @@ public class CourseDataKSS extends BaseCourseEntity {
     private Long id;
 
     @Enumerated(value = EnumType.STRING)
-    private CourseDataCategory CourseDataCategory;
+    private CourseDataCategory courseDataCategory;
 
     @OneToMany(mappedBy = "courseDataKSS")
     private List<CourseCourseDataRel> courseDataList = new ArrayList<>();

--- a/src/main/java/com/konkuk/Eodikase/domain/data/entity/CourseDataNS.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/entity/CourseDataNS.java
@@ -17,7 +17,7 @@ public class CourseDataNS  extends BaseCourseEntity {
     private Long id;
 
     @Enumerated(value = EnumType.STRING)
-    private CourseDataCategory CourseDataCategory;
+    private CourseDataCategory courseDataCategory;
 
     @OneToMany(mappedBy = "courseDataNS")
     private List<CourseCourseDataRel> courseDataList = new ArrayList<>();

--- a/src/main/java/com/konkuk/Eodikase/domain/data/entity/CourseDataSBG.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/entity/CourseDataSBG.java
@@ -3,7 +3,6 @@ package com.konkuk.Eodikase.domain.data.entity;
 import com.konkuk.Eodikase.domain.audit.BaseCourseEntity;
 import com.konkuk.Eodikase.domain.course.entity.CourseCourseDataRel;
 import lombok.Getter;
-import lombok.Setter;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -17,7 +16,7 @@ public class CourseDataSBG  extends BaseCourseEntity {
     private Long id;
 
     @Enumerated(value = EnumType.STRING)
-    private CourseDataCategory CourseDataCategory;
+    private CourseDataCategory courseDataCategory;
 
     @OneToMany(mappedBy = "courseDataSBG")
     private List<CourseCourseDataRel> courseDataList = new ArrayList<>();

--- a/src/main/java/com/konkuk/Eodikase/domain/data/entity/CourseDataSH.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/entity/CourseDataSH.java
@@ -3,7 +3,6 @@ package com.konkuk.Eodikase.domain.data.entity;
 import com.konkuk.Eodikase.domain.audit.BaseCourseEntity;
 import com.konkuk.Eodikase.domain.course.entity.CourseCourseDataRel;
 import lombok.Getter;
-import lombok.Setter;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -17,7 +16,7 @@ public class CourseDataSH  extends BaseCourseEntity {
     private Long id;
 
     @Enumerated(value = EnumType.STRING)
-    private CourseDataCategory CourseDataCategory;
+    private CourseDataCategory courseDataCategory;
 
     @OneToMany(mappedBy = "courseDataSH")
     private List<CourseCourseDataRel> courseDataList = new ArrayList<>();

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataEMRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataEMRepository.java
@@ -1,7 +1,11 @@
 package com.konkuk.Eodikase.domain.data.repository;
 
+import com.konkuk.Eodikase.domain.data.entity.CourseDataCategory;
 import com.konkuk.Eodikase.domain.data.entity.CourseDataEM;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CourseDataEMRepository extends JpaRepository<CourseDataEM, Long> {
+    List<CourseDataEM> findByCourseDataCategory(CourseDataCategory category);
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataEMRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataEMRepository.java
@@ -1,0 +1,7 @@
+package com.konkuk.Eodikase.domain.data.repository;
+
+import com.konkuk.Eodikase.domain.data.entity.CourseDataEM;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseDataEMRepository extends JpaRepository<CourseDataEM, Long> {
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataEMRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataEMRepository.java
@@ -1,0 +1,8 @@
+package com.konkuk.Eodikase.domain.data.repository;
+
+import com.konkuk.Eodikase.domain.data.entity.CourseDataEM;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseDataEMRepository extends JpaRepository<CourseDataEM,Long> {
+
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataHIRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataHIRepository.java
@@ -1,0 +1,7 @@
+package com.konkuk.Eodikase.domain.data.repository;
+
+import com.konkuk.Eodikase.domain.data.entity.CourseDataHI;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseDataHIRepository extends JpaRepository<CourseDataHI, Long> {
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataHIRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataHIRepository.java
@@ -1,8 +1,11 @@
 package com.konkuk.Eodikase.domain.data.repository;
 
+import com.konkuk.Eodikase.domain.data.entity.CourseDataCategory;
 import com.konkuk.Eodikase.domain.data.entity.CourseDataHI;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CourseDataHIRepository extends JpaRepository<CourseDataHI, Long> {
+import java.util.List;
 
+public interface CourseDataHIRepository extends JpaRepository<CourseDataHI, Long> {
+    List<CourseDataHI> findByCourseDataCategory(CourseDataCategory category);
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataHIRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataHIRepository.java
@@ -1,0 +1,8 @@
+package com.konkuk.Eodikase.domain.data.repository;
+
+import com.konkuk.Eodikase.domain.data.entity.CourseDataHI;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseDataHIRepository extends JpaRepository<CourseDataHI,Long> {
+
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataHSERepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataHSERepository.java
@@ -1,8 +1,11 @@
 package com.konkuk.Eodikase.domain.data.repository;
 
+import com.konkuk.Eodikase.domain.data.entity.CourseDataCategory;
 import com.konkuk.Eodikase.domain.data.entity.CourseDataHSE;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CourseDataHSERepository extends JpaRepository<CourseDataHSE, Long> {
+import java.util.List;
 
+public interface CourseDataHSERepository extends JpaRepository<CourseDataHSE, Long> {
+    List<CourseDataHSE> findByCourseDataCategory(CourseDataCategory category);
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataHSERepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataHSERepository.java
@@ -1,0 +1,7 @@
+package com.konkuk.Eodikase.domain.data.repository;
+
+import com.konkuk.Eodikase.domain.data.entity.CourseDataHSE;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseDataHSERepository extends JpaRepository<CourseDataHSE, Long> {
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataHSERepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataHSERepository.java
@@ -1,0 +1,8 @@
+package com.konkuk.Eodikase.domain.data.repository;
+
+import com.konkuk.Eodikase.domain.data.entity.CourseDataHSE;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseDataHSERepository extends JpaRepository<CourseDataHSE,Long> {
+
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataKSSRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataKSSRepository.java
@@ -1,8 +1,11 @@
 package com.konkuk.Eodikase.domain.data.repository;
 
+import com.konkuk.Eodikase.domain.data.entity.CourseDataCategory;
 import com.konkuk.Eodikase.domain.data.entity.CourseDataKSS;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CourseDataKSSRepository extends JpaRepository<CourseDataKSS, Long> {
+import java.util.List;
 
+public interface CourseDataKSSRepository extends JpaRepository<CourseDataKSS, Long> {
+    List<CourseDataKSS> findByCourseDataCategory(CourseDataCategory category);
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataKSSRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataKSSRepository.java
@@ -1,0 +1,7 @@
+package com.konkuk.Eodikase.domain.data.repository;
+
+import com.konkuk.Eodikase.domain.data.entity.CourseDataKSS;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseDataKSSRepository extends JpaRepository<CourseDataKSS, Long> {
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataKSSRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataKSSRepository.java
@@ -1,0 +1,8 @@
+package com.konkuk.Eodikase.domain.data.repository;
+
+import com.konkuk.Eodikase.domain.data.entity.CourseDataKSS;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseDataKSSRepository extends JpaRepository<CourseDataKSS,Long> {
+
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataNSRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataNSRepository.java
@@ -1,0 +1,8 @@
+package com.konkuk.Eodikase.domain.data.repository;
+
+import com.konkuk.Eodikase.domain.data.entity.CourseDataNS;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseDataNSRepository extends JpaRepository<CourseDataNS, Long> {
+
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataNSRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataNSRepository.java
@@ -1,8 +1,11 @@
 package com.konkuk.Eodikase.domain.data.repository;
 
+import com.konkuk.Eodikase.domain.data.entity.CourseDataCategory;
 import com.konkuk.Eodikase.domain.data.entity.CourseDataNS;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CourseDataNSRepository extends JpaRepository<CourseDataNS, Long> {
+import java.util.List;
 
+public interface CourseDataNSRepository extends JpaRepository<CourseDataNS, Long> {
+    List<CourseDataNS> findByCourseDataCategory(CourseDataCategory category);
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataNSRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataNSRepository.java
@@ -1,0 +1,7 @@
+package com.konkuk.Eodikase.domain.data.repository;
+
+import com.konkuk.Eodikase.domain.data.entity.CourseDataNS;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseDataNSRepository extends JpaRepository<CourseDataNS, Long> {
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataRepository.java
@@ -1,8 +1,0 @@
-package com.konkuk.Eodikase.domain.data.repository;
-
-import com.konkuk.Eodikase.domain.data.entity.CourseDataCategory;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface CourseDataRepository extends JpaRepository<CourseDataCategory, Long> {
-
-}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataRepository.java
@@ -1,5 +1,0 @@
-package com.konkuk.Eodikase.domain.data.repository;
-
-public interface CourseDataRepository {
-
-}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataRepository.java
@@ -1,5 +1,8 @@
 package com.konkuk.Eodikase.domain.data.repository;
 
-public interface CourseDataRepository {
+import com.konkuk.Eodikase.domain.data.entity.CourseDataCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseDataRepository extends JpaRepository<CourseDataCategory, Long> {
 
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataSBGRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataSBGRepository.java
@@ -1,0 +1,7 @@
+package com.konkuk.Eodikase.domain.data.repository;
+
+import com.konkuk.Eodikase.domain.data.entity.CourseDataSBG;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseDataSBGRepository extends JpaRepository<CourseDataSBG, Long> {
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataSBGRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataSBGRepository.java
@@ -1,0 +1,8 @@
+package com.konkuk.Eodikase.domain.data.repository;
+
+import com.konkuk.Eodikase.domain.data.entity.CourseDataSBG;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseDataSBGRepository extends JpaRepository<CourseDataSBG, Long> {
+
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataSBGRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataSBGRepository.java
@@ -1,8 +1,11 @@
 package com.konkuk.Eodikase.domain.data.repository;
 
+import com.konkuk.Eodikase.domain.data.entity.CourseDataCategory;
 import com.konkuk.Eodikase.domain.data.entity.CourseDataSBG;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CourseDataSBGRepository extends JpaRepository<CourseDataSBG, Long> {
+import java.util.List;
 
+public interface CourseDataSBGRepository extends JpaRepository<CourseDataSBG, Long> {
+    List<CourseDataSBG> findByCourseDataCategory(CourseDataCategory category);
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataSHRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataSHRepository.java
@@ -1,0 +1,7 @@
+package com.konkuk.Eodikase.domain.data.repository;
+
+import com.konkuk.Eodikase.domain.data.entity.CourseDataSH;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseDataSHRepository extends JpaRepository<CourseDataSH, Long> {
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataSHRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataSHRepository.java
@@ -1,8 +1,11 @@
 package com.konkuk.Eodikase.domain.data.repository;
 
+import com.konkuk.Eodikase.domain.data.entity.CourseDataCategory;
 import com.konkuk.Eodikase.domain.data.entity.CourseDataSH;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CourseDataSHRepository extends JpaRepository<CourseDataSH, Long> {
+import java.util.List;
 
+public interface CourseDataSHRepository extends JpaRepository<CourseDataSH, Long> {
+    List<CourseDataSH> findByCourseDataCategory(CourseDataCategory category);
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataSHRepository.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/repository/CourseDataSHRepository.java
@@ -1,0 +1,8 @@
+package com.konkuk.Eodikase.domain.data.repository;
+
+import com.konkuk.Eodikase.domain.data.entity.CourseDataSH;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseDataSHRepository extends JpaRepository<CourseDataSH, Long> {
+
+}

--- a/src/main/java/com/konkuk/Eodikase/domain/data/service/CourseDataService.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/service/CourseDataService.java
@@ -32,7 +32,7 @@ public class CourseDataService {
     private final CourseDataSHRepository courseDataSHRepository;
 
     // 첫 번째 코스 아이템 조회
-    public FilteredCourseDataResponse filtersCourseData(
+    public FilteredCourseDataResponse filtersFirstCourseData(
             Long memberId, String region, String type, int stage, FilteredCourseDataRequest request,
             Integer page, int count
     ) {
@@ -49,9 +49,7 @@ public class CourseDataService {
                 filtersCourseDataByRadius(filteredDataByRegionAndType, mapX, mapY, stage);
 
         // 순서 필터링 (첫 번째 순서인 경우에만 별점순)
-        FilteredCourseDataResponse filteredDataByOrder = filtersCourseDataByOrder(
-                filteredDataByRadius, type, page, count);
-        return filteredDataByOrder;
+        return filtersCourseDataByOrder(filteredDataByRadius, type, page, count);
     }
 
     private List<FilteredCourseDataByRegionAndTypeResponse> filtersCourseDataByRegionAndType(String region, String type) {

--- a/src/main/java/com/konkuk/Eodikase/domain/data/service/CourseDataService.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/service/CourseDataService.java
@@ -10,7 +10,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class CourseDataService {
 
-    public GetFilteredCourseDataResponse filtersCourseDataByType(String region, String type, String order) {
+    public GetFilteredCourseDataResponse filtersCourseDataByType(String region, String category, String order) {
+
         // 순서 필터링 (첫 번째 순서인 경우에만 별점 + x, y위치 고려해서 거리순)
         // 지역 필터링
         // 매장 타입 필터링

--- a/src/main/java/com/konkuk/Eodikase/domain/data/service/CourseDataService.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/service/CourseDataService.java
@@ -1,5 +1,6 @@
 package com.konkuk.Eodikase.domain.data.service;
 
+import com.konkuk.Eodikase.domain.data.dto.response.GetFilteredCourseDataResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,5 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class CourseDataService {
 
+    public GetFilteredCourseDataResponse filtersCourseDataByType(String region, String type) {
 
+    }
 }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/service/CourseDataService.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/service/CourseDataService.java
@@ -64,77 +64,63 @@ public class CourseDataService {
             // CourseDataEM를 FilteredCourseDataByRegionAndTypeResponse로 변환하여 추가
             for (CourseDataEM data : filteredByData) {
                 FilteredCourseDataByRegionAndTypeResponse response
-                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(),
-                        data.getCategory(), data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(),
-                        data.getHref(), data.getOperatingTime(), data.getReviewCount(), data.getImageUrl(),
-                        data.getImg1(), data.getImg2(), data.getImg3(),
-                        data.getLat(), data.getLng(), data.getAddr(), data.getPoint());
+                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(), data.getCategory(),
+                        data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(), data.getOperatingTime(),
+                        data.getReviewCount(), data.getImageUrl(), data.getLat(), data.getLng());
                 filteredDataList.add(response);
             }
         } else if (region.equals("HI")) {
             List<CourseDataHI> filteredByData = courseDataHIRepository.findByCourseDataCategory(category);
             for (CourseDataHI data : filteredByData) {
                 FilteredCourseDataByRegionAndTypeResponse response
-                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(),
-                        data.getCategory(), data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(),
-                        data.getHref(), data.getOperatingTime(), data.getReviewCount(), data.getImageUrl(),
-                        data.getImg1(), data.getImg2(), data.getImg3(),
-                        data.getLat(), data.getLng(), data.getAddr(), data.getPoint());
+                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(), data.getCategory(),
+                        data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(), data.getOperatingTime(),
+                        data.getReviewCount(), data.getImageUrl(), data.getLat(), data.getLng());
                 filteredDataList.add(response);
             }
         } else if (region.equals("HSE")) {
             List<CourseDataHSE> filteredByData = courseDataHSERepository.findByCourseDataCategory(category);
             for (CourseDataHSE data : filteredByData) {
                 FilteredCourseDataByRegionAndTypeResponse response
-                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(),
-                        data.getCategory(), data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(),
-                        data.getHref(), data.getOperatingTime(), data.getReviewCount(), data.getImageUrl(),
-                        data.getImg1(), data.getImg2(), data.getImg3(),
-                        data.getLat(), data.getLng(), data.getAddr(), data.getPoint());
+                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(), data.getCategory(),
+                        data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(), data.getOperatingTime(),
+                        data.getReviewCount(), data.getImageUrl(), data.getLat(), data.getLng());
                 filteredDataList.add(response);
             }
         } else if (region.equals("KSS")) {
             List<CourseDataKSS> filteredByData= courseDataKSSRepository.findByCourseDataCategory(category);
             for (CourseDataKSS data : filteredByData) {
                 FilteredCourseDataByRegionAndTypeResponse response
-                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(),
-                        data.getCategory(), data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(),
-                        data.getHref(), data.getOperatingTime(), data.getReviewCount(), data.getImageUrl(),
-                        data.getImg1(), data.getImg2(), data.getImg3(),
-                        data.getLat(), data.getLng(), data.getAddr(), data.getPoint());
+                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(), data.getCategory(),
+                        data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(), data.getOperatingTime(),
+                        data.getReviewCount(), data.getImageUrl(), data.getLat(), data.getLng());
                 filteredDataList.add(response);
             }
         } else if (region.equals("NS")) {
             List<CourseDataNS> filteredByData= courseDataNSRepository.findByCourseDataCategory(category);
             for (CourseDataNS data : filteredByData) {
                 FilteredCourseDataByRegionAndTypeResponse response
-                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(),
-                        data.getCategory(), data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(),
-                        data.getHref(), data.getOperatingTime(), data.getReviewCount(), data.getImageUrl(),
-                        data.getImg1(), data.getImg2(), data.getImg3(),
-                        data.getLat(), data.getLng(), data.getAddr(), data.getPoint());
+                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(), data.getCategory(),
+                        data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(), data.getOperatingTime(),
+                        data.getReviewCount(), data.getImageUrl(), data.getLat(), data.getLng());
                 filteredDataList.add(response);
             }
         } else if (region.equals("SBG")) {
             List<CourseDataSBG> filteredByData= courseDataSBGRepository.findByCourseDataCategory(category);
             for (CourseDataSBG data : filteredByData) {
                 FilteredCourseDataByRegionAndTypeResponse response
-                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(),
-                        data.getCategory(), data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(),
-                        data.getHref(), data.getOperatingTime(), data.getReviewCount(), data.getImageUrl(),
-                        data.getImg1(), data.getImg2(), data.getImg3(),
-                        data.getLat(), data.getLng(), data.getAddr(), data.getPoint());
+                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(), data.getCategory(),
+                        data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(), data.getOperatingTime(),
+                        data.getReviewCount(), data.getImageUrl(), data.getLat(), data.getLng());
                 filteredDataList.add(response);
             }
         } else if (region.equals("SH")) {
             List<CourseDataSH> filteredByData= courseDataSHRepository.findByCourseDataCategory(category);
             for (CourseDataSH data : filteredByData) {
                 FilteredCourseDataByRegionAndTypeResponse response
-                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(),
-                        data.getCategory(), data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(),
-                        data.getHref(), data.getOperatingTime(), data.getReviewCount(), data.getImageUrl(),
-                        data.getImg1(), data.getImg2(), data.getImg3(),
-                        data.getLat(), data.getLng(), data.getAddr(), data.getPoint());
+                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(), data.getCategory(),
+                        data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(), data.getOperatingTime(),
+                        data.getReviewCount(), data.getImageUrl(), data.getLat(), data.getLng());
                 filteredDataList.add(response);
             }
         } else {
@@ -177,10 +163,8 @@ public class CourseDataService {
             if (distance <= radius) {
                 FilteredCourseDataByRadiusResponse response = new FilteredCourseDataByRadiusResponse(
                         data.getId(), data.getName(), data.getCategory(), data.getLocation(),
-                        data.getPhoneNumber(), data.getScoreByNaver(), data.getHref(),
-                        data.getOperatingTime(), data.getReviewCount(), data.getImageUrl(),
-                        data.getImg1(), data.getImg2(), data.getImg3(), data.getLat(), data.getLng(),
-                        data.getAddr(), data.getPoint()
+                        data.getPhoneNumber(), data.getScoreByNaver(), data.getOperatingTime(), data.getReviewCount(),
+                        data.getImageUrl(), data.getLat(), data.getLng()
                 );
                 filteredDataByRadius.add(response);
             }

--- a/src/main/java/com/konkuk/Eodikase/domain/data/service/CourseDataService.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/data/service/CourseDataService.java
@@ -1,19 +1,203 @@
 package com.konkuk.Eodikase.domain.data.service;
 
-import com.konkuk.Eodikase.domain.data.dto.response.GetFilteredCourseDataResponse;
+import com.konkuk.Eodikase.domain.data.dto.request.FilteredCourseDataRequest;
+import com.konkuk.Eodikase.domain.data.dto.response.FilteredCourseDataByRadiusResponse;
+import com.konkuk.Eodikase.domain.data.dto.response.FilteredCourseDataByRegionAndTypeResponse;
+import com.konkuk.Eodikase.domain.data.dto.response.FilteredCourseDataResponse;
+import com.konkuk.Eodikase.domain.data.entity.*;
+import com.konkuk.Eodikase.domain.data.repository.*;
+import com.konkuk.Eodikase.domain.member.repository.MemberRepository;
+import com.konkuk.Eodikase.exception.badrequest.InvalidRegionException;
+import com.konkuk.Eodikase.exception.notfound.NotFoundMemberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CourseDataService {
 
-    public GetFilteredCourseDataResponse filtersCourseDataByType(String region, String category, String order) {
+    private final MemberRepository memberRepository;
+    private final CourseDataEMRepository courseDataEMRepository;
+    private final CourseDataHIRepository courseDataHIRepository;
+    private final CourseDataHSERepository courseDataHSERepository;
+    private final CourseDataKSSRepository courseDataKSSRepository;
+    private final CourseDataNSRepository courseDataNSRepository;
+    private final CourseDataSBGRepository courseDataSBGRepository;
+    private final CourseDataSHRepository courseDataSHRepository;
 
-        // 순서 필터링 (첫 번째 순서인 경우에만 별점 + x, y위치 고려해서 거리순)
-        // 지역 필터링
-        // 매장 타입 필터링
+    // 첫 번째 코스 아이템 조회
+    public FilteredCourseDataResponse filtersCourseData(
+            Long memberId, String region, String type, int stage, FilteredCourseDataRequest request,
+            Integer page, int count
+    ) {
+        memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+        // 지역, 타입 필터링
+        List<FilteredCourseDataByRegionAndTypeResponse> filteredDataByRegionAndType =
+                filtersCourseDataByRegionAndType(region, type);
+
+        // 반경 필터링
+        double mapX = request.getLat();
+        double mapY = request.getLng();
+        List<FilteredCourseDataByRadiusResponse> filteredDataByRadius =
+                filtersCourseDataByRadius(filteredDataByRegionAndType, mapX, mapY, stage);
+
+        // 순서 필터링 (첫 번째 순서인 경우에만 별점순)
+        FilteredCourseDataResponse filteredDataByOrder = filtersCourseDataByOrder(
+                filteredDataByRadius, type, page, count);
+        return filteredDataByOrder;
+    }
+
+    private List<FilteredCourseDataByRegionAndTypeResponse> filtersCourseDataByRegionAndType(String region, String type) {
+        CourseDataCategory category = CourseDataCategory.from(type);
+        List<FilteredCourseDataByRegionAndTypeResponse> filteredDataList = new ArrayList<>();
+
+        if (region.equals("EM")) {
+            List<CourseDataEM> filteredByData = courseDataEMRepository.findByCourseDataCategory(category);
+
+            // CourseDataEM를 FilteredCourseDataByRegionAndTypeResponse로 변환하여 추가
+            for (CourseDataEM data : filteredByData) {
+                FilteredCourseDataByRegionAndTypeResponse response
+                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(),
+                        data.getCategory(), data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(),
+                        data.getHref(), data.getOperatingTime(), data.getReviewCount(), data.getImageUrl(),
+                        data.getImg1(), data.getImg2(), data.getImg3(),
+                        data.getLat(), data.getLng(), data.getAddr(), data.getPoint());
+                filteredDataList.add(response);
+            }
+        } else if (region.equals("HI")) {
+            List<CourseDataHI> filteredByData = courseDataHIRepository.findByCourseDataCategory(category);
+            for (CourseDataHI data : filteredByData) {
+                FilteredCourseDataByRegionAndTypeResponse response
+                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(),
+                        data.getCategory(), data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(),
+                        data.getHref(), data.getOperatingTime(), data.getReviewCount(), data.getImageUrl(),
+                        data.getImg1(), data.getImg2(), data.getImg3(),
+                        data.getLat(), data.getLng(), data.getAddr(), data.getPoint());
+                filteredDataList.add(response);
+            }
+        } else if (region.equals("HSE")) {
+            List<CourseDataHSE> filteredByData = courseDataHSERepository.findByCourseDataCategory(category);
+            for (CourseDataHSE data : filteredByData) {
+                FilteredCourseDataByRegionAndTypeResponse response
+                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(),
+                        data.getCategory(), data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(),
+                        data.getHref(), data.getOperatingTime(), data.getReviewCount(), data.getImageUrl(),
+                        data.getImg1(), data.getImg2(), data.getImg3(),
+                        data.getLat(), data.getLng(), data.getAddr(), data.getPoint());
+                filteredDataList.add(response);
+            }
+        } else if (region.equals("KSS")) {
+            List<CourseDataKSS> filteredByData= courseDataKSSRepository.findByCourseDataCategory(category);
+            for (CourseDataKSS data : filteredByData) {
+                FilteredCourseDataByRegionAndTypeResponse response
+                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(),
+                        data.getCategory(), data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(),
+                        data.getHref(), data.getOperatingTime(), data.getReviewCount(), data.getImageUrl(),
+                        data.getImg1(), data.getImg2(), data.getImg3(),
+                        data.getLat(), data.getLng(), data.getAddr(), data.getPoint());
+                filteredDataList.add(response);
+            }
+        } else if (region.equals("NS")) {
+            List<CourseDataNS> filteredByData= courseDataNSRepository.findByCourseDataCategory(category);
+            for (CourseDataNS data : filteredByData) {
+                FilteredCourseDataByRegionAndTypeResponse response
+                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(),
+                        data.getCategory(), data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(),
+                        data.getHref(), data.getOperatingTime(), data.getReviewCount(), data.getImageUrl(),
+                        data.getImg1(), data.getImg2(), data.getImg3(),
+                        data.getLat(), data.getLng(), data.getAddr(), data.getPoint());
+                filteredDataList.add(response);
+            }
+        } else if (region.equals("SBG")) {
+            List<CourseDataSBG> filteredByData= courseDataSBGRepository.findByCourseDataCategory(category);
+            for (CourseDataSBG data : filteredByData) {
+                FilteredCourseDataByRegionAndTypeResponse response
+                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(),
+                        data.getCategory(), data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(),
+                        data.getHref(), data.getOperatingTime(), data.getReviewCount(), data.getImageUrl(),
+                        data.getImg1(), data.getImg2(), data.getImg3(),
+                        data.getLat(), data.getLng(), data.getAddr(), data.getPoint());
+                filteredDataList.add(response);
+            }
+        } else if (region.equals("SH")) {
+            List<CourseDataSH> filteredByData= courseDataSHRepository.findByCourseDataCategory(category);
+            for (CourseDataSH data : filteredByData) {
+                FilteredCourseDataByRegionAndTypeResponse response
+                        = new FilteredCourseDataByRegionAndTypeResponse(data.getId(), data.getName(),
+                        data.getCategory(), data.getLocation(), data.getPhoneNumber(), data.getScoreByNaver(),
+                        data.getHref(), data.getOperatingTime(), data.getReviewCount(), data.getImageUrl(),
+                        data.getImg1(), data.getImg2(), data.getImg3(),
+                        data.getLat(), data.getLng(), data.getAddr(), data.getPoint());
+                filteredDataList.add(response);
+            }
+        } else {
+            throw new InvalidRegionException();
+        }
+        return filteredDataList;
+    }
+
+    private double haversine(double lat1, double lon1, double lat2, double lon2) {
+        final int R = 6371; // 지구의 반지름 (km)
+
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+
+        lat1 = Math.toRadians(lat1);
+        lat2 = Math.toRadians(lat2);
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+                Math.sin(dLon / 2) * Math.sin(dLon / 2) * Math.cos(lat1) * Math.cos(lat2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return R * c; // 두 지점 사이의 거리 (km)
+    }
+
+    private List<FilteredCourseDataByRadiusResponse> filtersCourseDataByRadius(
+            List<FilteredCourseDataByRegionAndTypeResponse> filteredDataByRegionAndType,
+            double mapX, double mapY, int stage
+    ) {
+        int radius = 350 * stage;
+        List<FilteredCourseDataByRadiusResponse> filteredDataByRadius = new ArrayList<>();
+
+        for (FilteredCourseDataByRegionAndTypeResponse data : filteredDataByRegionAndType) {
+            double dataLat = data.getLat();
+            double dataLng = data.getLng();
+
+            // 두 지점 간의 거리 계산
+            double distance = haversine(mapX, mapY, dataLat, dataLng);
+
+            // 거리가 반경 내에 있는 경우 데이터를 추가
+            if (distance <= radius) {
+                FilteredCourseDataByRadiusResponse response = new FilteredCourseDataByRadiusResponse(
+                        data.getId(), data.getName(), data.getCategory(), data.getLocation(),
+                        data.getPhoneNumber(), data.getScoreByNaver(), data.getHref(),
+                        data.getOperatingTime(), data.getReviewCount(), data.getImageUrl(),
+                        data.getImg1(), data.getImg2(), data.getImg3(), data.getLat(), data.getLng(),
+                        data.getAddr(), data.getPoint()
+                );
+                filteredDataByRadius.add(response);
+            }
+        }
+        return filteredDataByRadius;
+    }
+
+    private FilteredCourseDataResponse filtersCourseDataByOrder(
+            List<FilteredCourseDataByRadiusResponse> filteredDataList, String type, int page, int count) {
+        // 별점 높은 순으로 리턴
+        filteredDataList.sort(Comparator.comparing(FilteredCourseDataByRadiusResponse::getScoreByNaver)
+                .reversed());
+        int startIndex = page * count;
+        int endIndex = Math.min(startIndex + count, filteredDataList.size());
+        List<FilteredCourseDataByRadiusResponse> paginatedData = filteredDataList.subList(startIndex, endIndex);
+
+        FilteredCourseDataResponse response = new FilteredCourseDataResponse(type, paginatedData);
+        return response;
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/exception/badrequest/InvalidCourseDataCategoryException.java
+++ b/src/main/java/com/konkuk/Eodikase/exception/badrequest/InvalidCourseDataCategoryException.java
@@ -1,0 +1,8 @@
+package com.konkuk.Eodikase.exception.badrequest;
+
+public class InvalidCourseDataCategoryException extends BadRequestException {
+
+    public InvalidCourseDataCategoryException() {
+        super("코스 데이터 카테고리 명이 올바르지 않습니다.", 3001);
+    }
+}

--- a/src/main/java/com/konkuk/Eodikase/exception/badrequest/InvalidDataOrderException.java
+++ b/src/main/java/com/konkuk/Eodikase/exception/badrequest/InvalidDataOrderException.java
@@ -1,0 +1,8 @@
+package com.konkuk.Eodikase.exception.badrequest;
+
+public class InvalidDataOrderException extends BadRequestException {
+
+    public InvalidDataOrderException() {
+        super("유효하지 않은 데이터 순서입니다.", 3002);
+    }
+}

--- a/src/main/java/com/konkuk/Eodikase/exception/badrequest/InvalidOrderException.java
+++ b/src/main/java/com/konkuk/Eodikase/exception/badrequest/InvalidOrderException.java
@@ -1,8 +1,0 @@
-package com.konkuk.Eodikase.exception.badrequest;
-
-public class InvalidOrderException extends BadRequestException {
-
-    public InvalidOrderException() {
-        super("순서가 올바르지 않습니다.", 3002);
-    }
-}

--- a/src/main/java/com/konkuk/Eodikase/exception/badrequest/InvalidOrderException.java
+++ b/src/main/java/com/konkuk/Eodikase/exception/badrequest/InvalidOrderException.java
@@ -1,0 +1,8 @@
+package com.konkuk.Eodikase.exception.badrequest;
+
+public class InvalidOrderException extends BadRequestException {
+
+    public InvalidOrderException() {
+        super("순서가 올바르지 않습니다.", 3002);
+    }
+}

--- a/src/main/java/com/konkuk/Eodikase/exception/badrequest/InvalidRegionException.java
+++ b/src/main/java/com/konkuk/Eodikase/exception/badrequest/InvalidRegionException.java
@@ -1,0 +1,8 @@
+package com.konkuk.Eodikase.exception.badrequest;
+
+public class InvalidRegionException extends BadRequestException {
+
+    public InvalidRegionException() {
+        super("지역 명이 올바르지 않습니다.", 3000);
+    }
+}


### PR DESCRIPTION
## 개요
- 지역/타입/반경을 고려한 추천 코스 아이템 조회 GET API를 구현했습니다

## 작업사항
- 첫 번째 코스 아이템 추천 로직 작성
  - 지역 필터링
  - 사용자 마커 위도 경도를 기준으로 반경 필터링
  - 타입 필터링
  - 별점 내림차순으로 상위 7개 추천
- 두 번째 이상 코스 아이템 추천 로직 작성
  - 지역 필터링
  - 이전 음식점 위도 경도를 기준으로 반경 필터링  
  - 타입 필터링
  - 거리 + 별점 고려한 추천 로직
    - 먼저 거리가 가까운 순으로 정렬하여 추천
      - 거리가 같다면 -> 별점 높은 순으로 다시 정렬하여 추천   
    - 거리 + 별점 고려한 추천 로직은 안드로이드 프론트와 임의로 정한 로직이라 추후에 변경될 수 있습니다

## 주의사항
- 테스트 코드는 생략하였습니다
- API 호출 테스트 시, 스웨거가 아닌 포스트맨으로 호출하셔야 합니다
