### PR TITLE
fix: kakao 로그인 올바르지 않은 토큰에 대해 예외 처리

### DIFF
--- a/src/main/java/com/konkuk/Eodikase/domain/auth/service/AuthService.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/auth/service/AuthService.java
@@ -1,18 +1,16 @@
 package com.konkuk.Eodikase.domain.auth.service;
 
-import com.konkuk.Eodikase.dto.request.AuthLoginRequest;
-import com.konkuk.Eodikase.dto.request.KakaoLoginRequest;
-import com.konkuk.Eodikase.dto.response.OAuthTokenResponse;
-import com.konkuk.Eodikase.dto.response.TokenResponse;
 import com.konkuk.Eodikase.domain.member.entity.Member;
 import com.konkuk.Eodikase.domain.member.entity.MemberPlatform;
 import com.konkuk.Eodikase.domain.member.entity.MemberStatus;
 import com.konkuk.Eodikase.domain.member.repository.MemberRepository;
+import com.konkuk.Eodikase.dto.request.AuthLoginRequest;
+import com.konkuk.Eodikase.dto.request.KakaoLoginRequest;
+import com.konkuk.Eodikase.dto.response.OAuthTokenResponse;
+import com.konkuk.Eodikase.dto.response.TokenResponse;
 import com.konkuk.Eodikase.exception.badrequest.PasswordMismatchException;
-import com.konkuk.Eodikase.exception.notfound.NotFoundException;
 import com.konkuk.Eodikase.exception.notfound.NotFoundMemberException;
 import com.konkuk.Eodikase.exception.unauthorized.InactiveMemberException;
-import com.konkuk.Eodikase.exception.unauthorized.InvalidKakaoTokenException;
 import com.konkuk.Eodikase.security.auth.JwtTokenProvider;
 import com.konkuk.Eodikase.security.auth.OAuthPlatformMemberResponse;
 import com.konkuk.Eodikase.security.auth.kakao.KakaoOAuthUserProvider;
@@ -57,17 +55,13 @@ public class AuthService {
     }
 
     public OAuthTokenResponse kakaoOAuthLogin(KakaoLoginRequest request) {
-        try {
-            OAuthPlatformMemberResponse kakaoPlatformMember =
-                    kakaoOAuthUserProvider.getKakaoPlatformMember(request.getToken());
-            return generateOAuthTokenResponse(
-                    MemberPlatform.KAKAO,
-                    kakaoPlatformMember.getEmail(),
-                    kakaoPlatformMember.getPlatformId()
-            );
-        } catch (NotFoundException e) {
-            throw new InvalidKakaoTokenException();
-        }
+        OAuthPlatformMemberResponse kakaoPlatformMember =
+                kakaoOAuthUserProvider.getKakaoPlatformMember(request.getToken());
+        return generateOAuthTokenResponse(
+                MemberPlatform.KAKAO,
+                kakaoPlatformMember.getEmail(),
+                kakaoPlatformMember.getPlatformId()
+        );
     }
 
     private OAuthTokenResponse generateOAuthTokenResponse(MemberPlatform platform, String email, String platformId) {

--- a/src/main/java/com/konkuk/Eodikase/domain/auth/service/AuthService.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/auth/service/AuthService.java
@@ -9,8 +9,10 @@ import com.konkuk.Eodikase.domain.member.entity.MemberPlatform;
 import com.konkuk.Eodikase.domain.member.entity.MemberStatus;
 import com.konkuk.Eodikase.domain.member.repository.MemberRepository;
 import com.konkuk.Eodikase.exception.badrequest.PasswordMismatchException;
+import com.konkuk.Eodikase.exception.notfound.NotFoundException;
 import com.konkuk.Eodikase.exception.notfound.NotFoundMemberException;
 import com.konkuk.Eodikase.exception.unauthorized.InactiveMemberException;
+import com.konkuk.Eodikase.exception.unauthorized.InvalidKakaoTokenException;
 import com.konkuk.Eodikase.security.auth.JwtTokenProvider;
 import com.konkuk.Eodikase.security.auth.OAuthPlatformMemberResponse;
 import com.konkuk.Eodikase.security.auth.kakao.KakaoOAuthUserProvider;
@@ -55,13 +57,17 @@ public class AuthService {
     }
 
     public OAuthTokenResponse kakaoOAuthLogin(KakaoLoginRequest request) {
-        OAuthPlatformMemberResponse kakaoPlatformMember =
-                kakaoOAuthUserProvider.getKakaoPlatformMember(request.getToken());
-        return generateOAuthTokenResponse(
-                MemberPlatform.KAKAO,
-                kakaoPlatformMember.getEmail(),
-                kakaoPlatformMember.getPlatformId()
-        );
+        try {
+            OAuthPlatformMemberResponse kakaoPlatformMember =
+                    kakaoOAuthUserProvider.getKakaoPlatformMember(request.getToken());
+            return generateOAuthTokenResponse(
+                    MemberPlatform.KAKAO,
+                    kakaoPlatformMember.getEmail(),
+                    kakaoPlatformMember.getPlatformId()
+            );
+        } catch (NotFoundException e) {
+            throw new InvalidKakaoTokenException();
+        }
     }
 
     private OAuthTokenResponse generateOAuthTokenResponse(MemberPlatform platform, String email, String platformId) {

--- a/src/main/java/com/konkuk/Eodikase/security/auth/kakao/KakaoOAuthUserProvider.java
+++ b/src/main/java/com/konkuk/Eodikase/security/auth/kakao/KakaoOAuthUserProvider.java
@@ -20,7 +20,7 @@ public class KakaoOAuthUserProvider {
             KakaoUserRequest kakaoUserRequest = new KakaoUserRequest("[\"kakao_account.email\"]");
             KakaoUser user = kakaoUserClient.getUser(kakaoUserRequest, AUTHORIZATION_BEARER + token);
             return new OAuthPlatformMemberResponse(String.valueOf(user.getId()), user.getEmail());
-        } catch (FeignException.NotFound e) {
+        } catch (FeignException e) {
             throw new InvalidKakaoTokenException();
         }
     }

--- a/src/main/java/com/konkuk/Eodikase/security/auth/kakao/KakaoOAuthUserProvider.java
+++ b/src/main/java/com/konkuk/Eodikase/security/auth/kakao/KakaoOAuthUserProvider.java
@@ -20,7 +20,7 @@ public class KakaoOAuthUserProvider {
             KakaoUserRequest kakaoUserRequest = new KakaoUserRequest("[\"kakao_account.email\"]");
             KakaoUser user = kakaoUserClient.getUser(kakaoUserRequest, AUTHORIZATION_BEARER + token);
             return new OAuthPlatformMemberResponse(String.valueOf(user.getId()), user.getEmail());
-        } catch (FeignException.Unauthorized e) {
+        } catch (FeignException.NotFound e) {
             throw new InvalidKakaoTokenException();
         }
     }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -26,12 +26,6 @@ security.jwt.token:
   secret-key: testtesttesttesttesttesttesttesttesttesttest
   expire-length: 864000
 
-oauth:
-  kakao:
-    client-id: test
-    client-secret: test
-    redirect-uri: test
-
 cloud:
   aws:
     s3:


### PR DESCRIPTION
## 개요
- 카카오 로그인에서 올바르지 않은 토큰에 대해 예외 처리했습니다.

## 작업사항
- 

## 주의사항
- 
- 
- 
