### PR TITLE
fix: 타입별 코스 아이템 조회 응답 필드 수정

### DIFF
--- a/src/main/java/com/konkuk/Eodikase/dto/response/data/FilteredCourseDataResponse.java
+++ b/src/main/java/com/konkuk/Eodikase/dto/response/data/FilteredCourseDataResponse.java
@@ -9,6 +9,6 @@ import java.util.List;
 @AllArgsConstructor
 public class FilteredCourseDataResponse {
     private String datasType;
-    private List<FilteredCourseDataByRadiusResponse> datas;
+    private List<FilteredCourseDataByRadiusResponse> contents;
     private Boolean isEnd;
 }


### PR DESCRIPTION
## 개요
- 프론트의 요청으로 타입별 코스 아이템 조회 API에서 datas 필드를 contents로 수정했습니다.

## 작업사항
- FilteredCourseDataResponse 에서 datas 필드명 수정

## 주의사항
- 
- 
- 
