### PR TITLE
fix: 닉네임 유효성 및 기타 예외 코드 수정

### DIFF
--- a/src/main/java/com/konkuk/Eodikase/domain/member/entity/Member.java
+++ b/src/main/java/com/konkuk/Eodikase/domain/member/entity/Member.java
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 
-    private static final Pattern NICKNAME_REGEX = Pattern.compile("^[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣]{2,8}$");
+    private static final Pattern NICKNAME_REGEX = Pattern.compile("^[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣]{2,15}$");
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/konkuk/Eodikase/dto/request/auth/AuthLoginRequest.java
+++ b/src/main/java/com/konkuk/Eodikase/dto/request/auth/AuthLoginRequest.java
@@ -12,7 +12,7 @@ import javax.validation.constraints.NotBlank;
 @ToString
 public class AuthLoginRequest {
 
-    @Email(message = "1006:이메일 형식이 올바르지 않습니다.")
+    @Email(message = "1004:이메일 형식이 올바르지 않습니다.")
     @NotBlank(message = "1005:공백일 수 없습니다.")
     private String email;
 

--- a/src/main/java/com/konkuk/Eodikase/dto/request/auth/KakaoLoginRequest.java
+++ b/src/main/java/com/konkuk/Eodikase/dto/request/auth/KakaoLoginRequest.java
@@ -13,6 +13,6 @@ import javax.validation.constraints.NotBlank;
 @Getter
 public class KakaoLoginRequest {
 
-    @NotBlank(message = "1012:공백일 수 없습니다.")
+    @NotBlank(message = "1005:공백일 수 없습니다.")
     private String token;
 }

--- a/src/main/java/com/konkuk/Eodikase/dto/request/member/ResetPasswordRequest.java
+++ b/src/main/java/com/konkuk/Eodikase/dto/request/member/ResetPasswordRequest.java
@@ -10,6 +10,6 @@ import javax.validation.constraints.NotBlank;
 @ToString
 public class ResetPasswordRequest {
 
-    @NotBlank(message = "1012:공백일 수 없습니다.")
+    @NotBlank(message = "1005:공백일 수 없습니다.")
     private String password;
 }

--- a/src/main/java/com/konkuk/Eodikase/exception/badrequest/BlankKeywordException.java
+++ b/src/main/java/com/konkuk/Eodikase/exception/badrequest/BlankKeywordException.java
@@ -3,6 +3,6 @@ package com.konkuk.Eodikase.exception.badrequest;
 public class BlankKeywordException extends BadRequestException {
 
     public BlankKeywordException() {
-        super("키워드는 공백일 수 없습니다.", 3005);
+        super("키워드는 공백일 수 없습니다.", 3001);
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/exception/badrequest/InvalidNicknameException.java
+++ b/src/main/java/com/konkuk/Eodikase/exception/badrequest/InvalidNicknameException.java
@@ -3,6 +3,6 @@ package com.konkuk.Eodikase.exception.badrequest;
 public class InvalidNicknameException extends BadRequestException {
 
     public InvalidNicknameException() {
-        super("닉네임은 영어, 한글로만 구성된 2~6자여야 합니다.", 1001);
+        super("닉네임은 영어, 한글로만 구성된 2~15자여야 합니다.", 1001);
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/exception/badrequest/RegionNotMatchException.java
+++ b/src/main/java/com/konkuk/Eodikase/exception/badrequest/RegionNotMatchException.java
@@ -1,8 +1,0 @@
-package com.konkuk.Eodikase.exception.badrequest;
-
-public class RegionNotMatchException extends BadRequestException{
-
-    public RegionNotMatchException() {
-        super("코스데이터의 지역과 코스지역이 맞지 않습니다.", 3005);
-    }
-}

--- a/src/main/java/com/konkuk/Eodikase/exception/notfound/NotFoundCourseDataException.java
+++ b/src/main/java/com/konkuk/Eodikase/exception/notfound/NotFoundCourseDataException.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 public class NotFoundCourseDataException extends NotFoundException {
 
     public NotFoundCourseDataException() {
-        super("존재하지 않는 코스 데이터입니다.", 1007);
+        super("존재하지 않는 코스 데이터입니다.", 3003);
     }
 }

--- a/src/main/java/com/konkuk/Eodikase/exception/unauthorized/TokenExpiredException.java
+++ b/src/main/java/com/konkuk/Eodikase/exception/unauthorized/TokenExpiredException.java
@@ -3,6 +3,6 @@ package com.konkuk.Eodikase.exception.unauthorized;
 public class TokenExpiredException extends UnauthorizedException {
 
     public TokenExpiredException() {
-        super("로그인 인증 유효기간이 만료되었습니다. 다시 로그인 해주세요.", 1009);
+        super("로그인 인증 유효기간이 만료되었습니다. 다시 로그인 해주세요.", 1011);
     }
 }

--- a/src/test/java/com/konkuk/Eodikase/service/MemberServiceTest.java
+++ b/src/test/java/com/konkuk/Eodikase/service/MemberServiceTest.java
@@ -171,8 +171,8 @@ public class MemberServiceTest {
     }
 
     @ParameterizedTest
-    @DisplayName("닉네임이 2~8자가 아니면 예외를 반환한다")
-    @ValueSource(strings = {"감", "감자포테이토예에에"})
+    @DisplayName("닉네임이 2~15자가 아니면 예외를 반환한다")
+    @ValueSource(strings = {"감", "감자포테이토토토토토토토토토토토토토예에에"})
     void nicknameLengthValidation(String nickname) {
         assertThatThrownBy(() -> memberService.signUp(new MemberSignUpRequest("dlawotn3@naver.com",
                 "edks1234!", nickname)))


### PR DESCRIPTION
## 개요
- 프론트의 요청으로 닉네임 유효성 체크 시, 15자까지 허용하도록 바꿨습니다. 그 외, API 명세서와 예외코드가 불일치한 예외에 대해 다시 정리했습니다.

## 작업사항
- 닉네임 유효성 체크 정규표현식 수정
- 명세서와 코드가 불일치한 예외에 대해 수정

## 주의사항
- 
- 
- 
